### PR TITLE
OS X adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.py[cod]
+
+.py[co]
+build/
+bin/
+parts/
+tags
+keyring.egg-info
+develop-eggs
+.installed.cfg
+*.eggs/
+*.egg-info/
+*.egg
+dist/
+.idea

--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -50,6 +50,7 @@ class Keyring(KeyringBackend):
                 '-a', username,
                 '-s', service,
                 '-w', password,
+                '-T', '', #do NOT authorize any application by default (especially not security itself!)
                 '-U',
             ]
             call = subprocess.Popen(cmd, stderr=subprocess.PIPE,


### PR DESCRIPTION
Issue #144 details how any process can access the created passcode (through security) under Mac OS X. By explicitly NOT setting any allowed application to access the new item, any access now requires the user to input her passcode.

PS: I also added a .gitignore
