### PR TITLE
Add plain text AWS S3 backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.eggs
+keyring.egg-info

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,18 @@ directory in the project checkout::
     keyring-path=/home/kang/pyworkspace/python-keyring-lib/demo/
 
 
+S3 backend configuration
+------------------------
+
+The S3 backend needs to know what `KMS key <https://aws.amazon.com/kms/>`
+should be used for client-side encryption. The S3 backend tries reads that
+configuration option in the following order:
+
+* From environment variable `AWS_KMS_KEY_ID`
+* From key `kms_key_id` under the relevant profile section of the AWS CLI
+  configuration file.
+
+
 Write your own keyring backend
 ==============================
 

--- a/keyring/backends/S3.py
+++ b/keyring/backends/S3.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+
+from __future__ import with_statement
+
+import base64
+import abc
+import boto3
+import uuid
+
+from ..errors import PasswordDeleteError, PasswordGetError, InitError
+from ..backend import KeyringBackend
+from ..util.escape import escape as escape_for_s3
+
+
+def supported():
+    """Returns True if the S3 backed is supported on this system"""
+    try:
+        list(boto3.resource('s3').buckets.all())
+        return True
+    except:
+        return False
+
+
+class S3Backed(object):
+    def __init__(self):
+        """Creates a S3 bucket for the backend if one does not exist already"""
+        self.__s3 = None
+        self.__bucket = None
+
+    @property
+    def bucket(self):
+        if self.__bucket is None:
+            self.__bucket = self._find_bucket()
+        return self.__bucket
+
+    @property
+    def s3(self):
+        if self.__s3 is None:
+            self.__s3 = boto3.resource('s3')
+        return self.__s3
+
+    def _find_bucket(self):
+        """Finds the backend S3 bucket. The backend bucket must be called
+        keyring-[UUID].
+        """
+        bucket = [b for b in self.s3.buckets.all()
+                  if b.name.find('keyring-') == 0]
+        if len(bucket) == 0:
+            bucket_name = "keyring-{}".format(uuid.uuid4())
+            bucket = self.s3.Bucket(bucket_name)
+            bucket.create(ACL='private')
+        elif len(bucket) > 1:
+            msg = ("Can't tell which of these buckets to use for the keyring: "
+                   "{buckets}").format([b.name for b in bucket])
+            raise InitError(msg)
+        else:
+            bucket = bucket[0]
+        return bucket
+
+
+class BaseKeyring(S3Backed, KeyringBackend):
+    """
+    BaseS3Keyring is a S3-based implementation of keyring.
+    This keyring stores the password directly in S3 and provides methods
+    which may be overridden by subclasses to support
+    encryption and decryption. The encrypted payload is stored in base64
+    format.
+    """
+
+    @abc.abstractmethod
+    def encrypt(self, password):
+        """
+        Given a password (byte string), return an encrypted byte string.
+        """
+
+    @abc.abstractmethod
+    def decrypt(self, password_encrypted):
+        """
+        Given a password encrypted by a previous call to `encrypt`, return
+        the original byte string.
+        """
+
+    def get_password(self, service, username):
+        """Read the password from the S3 bucket.
+        """
+        service = escape_for_s3(service)
+        username = escape_for_s3(username)
+
+        # Read the password from S3
+        prefix = "{}/{}/secret.b64".format(service, username)
+        values = list(self.bucket.objects.filter(Prefix=prefix))
+        if len(values) == 0:
+            # service/username not found
+            return
+        if len(values) > 1:
+            msg = "Ambiguous prefix {prefix} in bucket {bucket}.".format(
+                prefix=prefix, bucket=self.bucket.name)
+            raise PasswordGetError(msg)
+        pwd_base64 = values[0].get()['Body'].read()
+        encrypted_pwd = base64.decodestring(pwd_base64)
+        return self.decrypt(encrypted_pwd).decode('utf-8')
+
+    def set_password(self, service, username, password):
+        """Write the password in the S3 bucket.
+        """
+        service = escape_for_s3(service)
+        username = escape_for_s3(username)
+
+        # encrypt and base64-encode the password
+        pwd_encrypted = self.encrypt(password.encode('utf-8'))
+        pwd_base64 = base64.encodestring(pwd_encrypted).decode()
+
+        # Save in S3
+        keyname = "{}/{}/secret.b64".format(service, username)
+        self.bucket.Object(keyname).put(ACL='private', Body=pwd_base64)
+
+    def delete_password(self, service, username):
+        """Delete the password for the username of the service.
+        """
+        service = escape_for_s3(service)
+        username = escape_for_s3(username)
+        prefix = "{}/{}/secret.b64".format(service, username)
+        objects = list(self.bucket.objects.filter(Prefix=prefix))
+        if len(objects) == 0:
+            msg = ("Password for service {service} and username {username} "
+                   "not found.").format(service=service, username=username)
+            raise PasswordDeleteError(msg)
+        elif len(objects) > 1:
+            msg = ("Multiple objects in bucket {bucket} match the prefix "
+                   "{prefix}.").format(bucket=self.bucket.name,
+                                       prefix=prefix)
+        else:
+            objects[0].delete()
+
+
+class PlaintextKeyring(BaseKeyring):
+    """Simple S3 Keyring with no encryption"""
+
+    priority = .5
+    "Applicable for all platforms, but not recommended"
+
+    def encrypt(self, password):
+        """Directly return the password itself.
+        """
+        return password
+
+    def decrypt(self, password_encrypted):
+        """Directly return encrypted password.
+        """
+        return password_encrypted

--- a/keyring/errors.py
+++ b/keyring/errors.py
@@ -4,6 +4,10 @@ class PasswordSetError(Exception):
     """Raised when the password can't be set.
     """
 
+class PasswordGetError(Exception):
+    """Raised when there is an error retrieving a password.
+    """
+
 class PasswordDeleteError(Exception):
     """Raised when the password can't be deleted.
     """

--- a/keyring/errors.py
+++ b/keyring/errors.py
@@ -16,6 +16,10 @@ class InitError(Exception):
     """Raised when the keyring could not be initialised
     """
 
+class ConfigError(Exception):
+    """Raised when a keyring has not been properly configured
+    """
+
 class ExceptionRaisedContext(object):
     """
     An exception-trapping context that indicates whether an exception was

--- a/keyring/tests/backends/test_S3.py
+++ b/keyring/tests/backends/test_S3.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+
+from ..test_backend import BackendBasicTests
+from ..py30compat import unittest
+from keyring.backends import S3
+
+
+@unittest.skipUnless(S3.supported(),
+                     "You need to configure the AWS credentials")
+class S3PlaintextKeychainTestCase(BackendBasicTests, unittest.TestCase):
+    def init_keyring(self):
+        return S3.PlaintextKeyring()

--- a/keyring/tests/backends/test_S3.py
+++ b/keyring/tests/backends/test_S3.py
@@ -10,4 +10,4 @@ from keyring.backends import S3
                      "You need to configure the AWS credentials")
 class S3PlaintextKeychainTestCase(BackendBasicTests, unittest.TestCase):
     def init_keyring(self):
-        return S3.PlaintextKeyring()
+        return S3.S3Keyring()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ def load(filename):
         raise ValueError("distutils requires ASCII")
     return result
 
+
 def encodes_as_ascii(string):
     try:
         string.encode('ascii')
@@ -41,6 +42,7 @@ test_requirements = [
     'fs>=0.5',
     'mock',
     'pycrypto',
+    'boto3>=1.1.3'
 ]
 "dependencies for running tests"
 


### PR DESCRIPTION
Very similar to the File backend but using Amazon's S3 as storage. A use case of this type of backend is to share credentials with AWS resources that have been associated to an IAM role that has access to the keyring's S3 bucket.  
