### PR TITLE
Gnome: specify required version for GnomeKeyring and drop the old hack

### DIFF
--- a/keyring/backends/Gnome.py
+++ b/keyring/backends/Gnome.py
@@ -1,10 +1,10 @@
 import os
 
 try:
-    from gi import Repository
-    if Repository.get_default().enumerate_versions('GnomeKeyring'):
-        from gi.repository import GnomeKeyring
-except ImportError:
+    import gi
+    gi.require_version('GnomeKeyring', '1.0')
+    from gi.repository import GnomeKeyring
+except (ImportError, ValueError):
     pass
 
 from ..backend import KeyringBackend


### PR DESCRIPTION
New versions of PyGObject print this warning:

```
PyGIWarning: GnomeKeyring was imported without specifying a version first.
Use gi.require_version('GnomeKeyring', '1.0') before import to ensure that the right version gets loaded.
```

Follow the advice and call require_version before importing. This also allows us to drop the old hacky check for GnomeKeyring existence.
