### PR TITLE
Add ability to specify keychain for OS X backend

### DIFF
--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -99,7 +99,7 @@ class Keyring(KeyringBackend):
         stdoutdata, stderrdata = call.communicate()
         return call.returncode
 
-    def get_password(self, service, username):
+    def get_password(self, service, username, keychain=None):
         if username is None:
             username = ''
         try:
@@ -111,6 +111,8 @@ class Keyring(KeyringBackend):
                 '-a', username,
                 '-s', service,
             ]
+            if keychain:
+                cmd.append(keychain)
             call = subprocess.Popen(
                 cmd,
                 stderr=subprocess.PIPE,

--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -24,6 +24,10 @@ class SecurityCommand(unicode_str):
 class Keyring(KeyringBackend):
     """Mac OS X Keychain"""
 
+    def __init__(self):
+        self.keychain = None
+
+
     # regex for extracting password from security call
     password_regex = re.compile("""password:\s*(?:0x(?P<hex>[0-9A-F]+)\s*)?"""
                                 """(?:"(?P<pw>.*)")?""")
@@ -111,6 +115,8 @@ class Keyring(KeyringBackend):
                 '-a', username,
                 '-s', service,
             ]
+            if self.keychain:
+                cmd.append(self.keychain)
             call = subprocess.Popen(
                 cmd,
                 stderr=subprocess.PIPE,
@@ -162,3 +168,17 @@ class Keyring(KeyringBackend):
                 raise del_error
         except:
             raise del_error
+
+    def set_keychain(self, keychain):
+        """Allows use of non-default keychain.
+
+        args:
+        keychain -- Absolute path to preferred keychain
+
+        OS X backend uses the ``security`` command, which can accept an
+        argument to specify a non-default keychain (default is usually
+        ``~/Library/Keychains/login.keychain``). This method allows keyring to
+        take advantage of this to also use non-default keychains if needed.
+        """
+
+        self.keychain = keychain

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -33,10 +33,10 @@ def get_keyring():
     return _keyring_backend
 
 
-def get_password(service_name, username, **kwargs):
+def get_password(service_name, username):
     """Get password from the specified service.
     """
-    return _keyring_backend.get_password(service_name, username, **kwargs)
+    return _keyring_backend.get_password(service_name, username)
 
 
 def set_password(service_name, username, password):

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -33,10 +33,10 @@ def get_keyring():
     return _keyring_backend
 
 
-def get_password(service_name, username):
+def get_password(service_name, username, **kwargs):
     """Get password from the specified service.
     """
-    return _keyring_backend.get_password(service_name, username)
+    return _keyring_backend.get_password(service_name, username, **kwargs)
 
 
 def set_password(service_name, username, password):


### PR DESCRIPTION
https://github.com/jaraco/keyring/issues/188

By default, the OS X backend uses the built-in `security` command to
store on retrieve passwords from the OS X keychain.

The `security` command, in turn, defaults to a user's
`~/Library/Keychains/login.keychain`. However, in certain settings such
as being called from `cron`, it will instead default to
`/Library/Keychains/System.keychain`, which will obviously not have the
user's passwords. It seems to use this as default even when being called
as a regular non-root user.

Many of the `security` subcommands have the flexibility to accept an
argument that specifies a non-default keychain. This commit gives the
default OS X Keyring backend `get_password` method the ability to accept
a keyword argument `keychain`. If given, this provides a specific
keychain to use and permits `python-keyring` to function in unusual
environments such as `cron`, without impairing its other functions.
