### PR TITLE
Format error message

### DIFF
--- a/keyring/util/platform_.py
+++ b/keyring/util/platform_.py
@@ -42,7 +42,9 @@ def _check_old_config_root():
 		msg = ("Keyring config exists only in the old location "
 			"{config_file_old} and should be moved to {config_file_new} "
 			"to work with this version of keyring.")
-		raise RuntimeError(msg)
+		formatted = msg.format(config_file_new=config_file_new,
+					config_file_old=config_file_old)
+		raise RuntimeError(formatted)
 
 def _config_root_Linux():
 	"""


### PR DESCRIPTION
This morning I got the following error message which wasn't altogether very helpful:

```
RuntimeError: Keyring config exists only in the old location {config_file_old} and should be moved to {config_file_new} to work with this version of keyring.
```

With this change I get the proper error message, stating I should move it from `.local/share/python-keyring` to `.config/python-keyring`.

I tried this with both Python 2.7 and 3.5.
