### PR TITLE
fix syntax of install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,9 +284,9 @@ the environment by running::
 
     python setup.py develop
 
-You then need to install the test requirements with something like:
+You then need to install the test requirements with something like::
 
-    pip install `python -c "import setup, subprocess; print(subprocess.list2cmdline(setup.test_requirements))"`
+    pip install $( python -c "import setup, subprocess; print(subprocess.list2cmdline(setup.test_requirements))" )
 
 Then, invoke your favorite test runner, e.g.::
 


### PR DESCRIPTION
There was a missing double semi-colon to denote a command which meant that the
backticks were being swallowed. Also, replace the backticks in favour of '$( )'
since that is the modern and recommended way.
