### PR TITLE
Remove mock from test_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ wheel = ['wheel'] if needs_wheel else []
 
 test_requirements = [
     'pytest>=2.8',
-    'mock',
 ]
 
 setup_params = dict(


### PR DESCRIPTION
It was only used by test_crypto.py, which has been removed from this repository.
