### PR TITLE
Make KWallet backend have lower priority than Secret Service backend

### DIFF
--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -30,7 +30,7 @@ class DBusKeyring(KeyringBackend):
             bus.get_object('org.kde.kwalletd5', '/modules/kwalletd5')
         except dbus.DBusException:
             raise RuntimeError('cannot connect to org.kde.kwalletd5')
-        return 5.1
+        return 4.9
 
     def __init__(self, *arg, **kw):
         super(DBusKeyring, self).__init__(*arg, **kw)


### PR DESCRIPTION
Secret Service is an XDG standard and thus should be preferred on systems where both protocols are available.

---

I recently upgraded Keyring (on GNOME system) and noticed that it now uses KWallet. Previously the priority was bigger, but limited to KDE desktops, so it was fine; but after the desktop check was removed, it should not have higher priority.
