### PR TITLE
Add support to specify DBus event loop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,6 +219,10 @@ The keyring lib has a few functions:
   keyring.
 * ``delete_password(service, username)``: Delete the password stored in
   keyring. If the password does not exist, it will raise an exception.
+* ``set_dbus_mainloop(mainloop)``: Sets the DBus event loop for backends that
+  use DBus (like kwallet). The provided ``mainloop`` should be the function
+  that returns the mainloop instance, such as
+  ``dbus.mainloop.glib.DBusGMainLoop``.
 
 ------------
 Get involved

--- a/keyring/__init__.py
+++ b/keyring/__init__.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger('keyring')
 
 from .core import (set_keyring, get_keyring, set_password, get_password,
-                  delete_password)
+                  delete_password, set_dbus_mainloop)
 from .getpassbackend import get_password as get_pass_get_password
 
 try:

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -30,6 +30,8 @@ class DBusKeyring(KeyringBackend):
             bus.get_object('org.kde.kwalletd5', '/modules/kwalletd5')
         except dbus.DBusException:
             raise RuntimeError('cannot connect to org.kde.kwalletd5')
+        finally:
+            bus.close()
         return 4.9
 
     def __init__(self, *arg, **kw):
@@ -39,6 +41,10 @@ class DBusKeyring(KeyringBackend):
     def connected(self):
         if self.handle >= 0:
             return True
+        # Set the DBus event loop to use if specified
+        from ..core import _dbus_mainloop
+        if _dbus_mainloop:
+            _dbus_mainloop(set_as_default=True)
         bus = dbus.SessionBus()
         wId = 0
         try:

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -20,6 +20,7 @@ from .backends import fail
 log = logging.getLogger(__name__)
 
 _keyring_backend = None
+_dbus_mainloop = None
 
 def set_keyring(keyring):
     """Set current keyring backend.
@@ -180,6 +181,21 @@ def _load_library_extensions():
                 init_func()
         except Exception as exc:
             log.exception("Error initializing plugin %s (%s).", ep, exc)
+
+def set_dbus_mainloop(mainloop):
+    """
+    Set the DBus event loop for keyring backends that use DBus (kwallet for
+    example). An example of using this in your glib app:
+        import keyring
+        from dbus.mainloop.glib import DBusGMainLoop
+        keyring.set_dbus_mainloop(DBusGMainLoop)
+    Other mainloops:
+        dbus.mainloop.qt.DBusQtMainLoop (PyQT4)
+        dbus.mainloop.qt5.DBusQtMainLoop (PyQT5)
+    """
+    global _dbus_mainloop
+    _dbus_mainloop = mainloop
+    init_backend()
 
 # init the _keyring_backend
 init_backend()


### PR DESCRIPTION
This adds the ability to specify the DBus event loop for backends that use DBus (kwallet).

I'm going to be honest, this is my first time playing with DBus, so any feedback/criticism is welcomed =D.

Signed-off-by: M. David Bennett mdavidbennett@syntheticworks.com
