### PR TITLE
Added License info to PKG-INFO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup_params = dict(
     description="Store and access your passwords safely.",
     long_description=long_description,
     url="https://github.com/jaraco/keyring",
+    license = "MIT",
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Before this change:

``` shell
$ pip show keyring

---
Metadata-Version: 2.0
Name: keyring
Version: 9.0
Summary: Store and access your passwords safely.
Home-page: https://github.com/jaraco/keyring
Author: Jason R. Coombs
Author-email: jaraco@jaraco.com
Installer: pip
License: UNKNOWN
[...]
```

With the change _License_ will be _MIT_
