### PR TITLE
KWallet keyring should store service name in a folder name rather than in username

### DIFF
--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -35,7 +35,29 @@ class DBusKeyring(KeyringBackend):
         super(DBusKeyring, self).__init__(*arg, **kw)
         self.handle = -1
 
-    def connected(self):
+    def _migrate(self, service):
+        old_folder = 'Python'
+        entry_list = []
+        if self.iface.hasFolder(self.handle, old_folder, self.appid):
+            entry_list = self.iface.readPasswordList(
+                    self.handle, old_folder, '*@*', self.appid)
+
+            for entry in entry_list.items():
+                key = entry[0]
+                password = entry[1]
+
+                username, service = key.rsplit('@', 1)
+                ret = self.iface.writePassword(
+                        self.handle, service, username, password, self.appid)
+                if ret == 0:
+                    self.iface.removeEntry(self.handle, old_folder, key, self.appid)
+
+            entry_list = self.iface.readPasswordList(
+                    self.handle, old_folder, '*', self.appid)
+            if not entry_list:
+                self.iface.removeFolder(self.handle, old_folder, self.appid)
+
+    def connected(self, service):
         if self.handle >= 0:
             return True
         bus = dbus.SessionBus()
@@ -49,12 +71,13 @@ class DBusKeyring(KeyringBackend):
             self.handle = -1
         if self.handle < 0:
             return False
+        self._migrate(service)
         return True
 
     def get_password(self, service, username):
         """Get password of the username for the service
         """
-        if not self.connected():
+        if not self.connected(service):
             # the user pressed "cancel" when prompted to unlock their keyring.
             return None
         if not self.iface.hasEntry(self.handle, service, username, self.appid):
@@ -65,7 +88,7 @@ class DBusKeyring(KeyringBackend):
     def set_password(self, service, username, password):
         """Set password for the username of the service
         """
-        if not self.connected():
+        if not self.connected(service):
             # the user pressed "cancel" when prompted to unlock their keyring.
             raise PasswordSetError("Cancelled by user")
         self.iface.writePassword(
@@ -74,7 +97,7 @@ class DBusKeyring(KeyringBackend):
     def delete_password(self, service, username):
         """Delete the password for the username of the service.
         """
-        if not self.connected():
+        if not self.connected(service):
             # the user pressed "cancel" when prompted to unlock their keyring.
             raise PasswordDeleteError("Cancelled by user")
         if not self.iface.hasEntry(self.handle, service, username, self.appid):

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -14,7 +14,6 @@ except ImportError:
 class DBusKeyring(KeyringBackend):
     """KDE KWallet via D-Bus"""
 
-    folder = 'Python'
     appid = 'Python program'
 
     @properties.ClassProperty
@@ -50,39 +49,34 @@ class DBusKeyring(KeyringBackend):
             self.handle = -1
         if self.handle < 0:
             return False
-        if not self.iface.hasFolder(self.handle, self.folder, self.appid):
-            self.iface.createFolder(self.handle, self.folder, self.appid)
         return True
 
     def get_password(self, service, username):
         """Get password of the username for the service
         """
-        key = username + '@' + service
         if not self.connected():
             # the user pressed "cancel" when prompted to unlock their keyring.
             return None
-        if not self.iface.hasEntry(self.handle, self.folder, key, self.appid):
+        if not self.iface.hasEntry(self.handle, service, username, self.appid):
             return None
         return self.iface.readPassword(
-            self.handle, self.folder, key, self.appid)
+            self.handle, service, username, self.appid)
 
     def set_password(self, service, username, password):
         """Set password for the username of the service
         """
-        key = username + '@' + service
         if not self.connected():
             # the user pressed "cancel" when prompted to unlock their keyring.
             raise PasswordSetError("Cancelled by user")
         self.iface.writePassword(
-            self.handle, self.folder, key, password, self.appid)
+            self.handle, service, username, password, self.appid)
 
     def delete_password(self, service, username):
         """Delete the password for the username of the service.
         """
-        key = username + '@' + service
         if not self.connected():
             # the user pressed "cancel" when prompted to unlock their keyring.
             raise PasswordDeleteError("Cancelled by user")
-        if not self.iface.hasEntry(self.handle, self.folder, key, self.appid):
+        if not self.iface.hasEntry(self.handle, service, username, self.appid):
             raise PasswordDeleteError("Password not found")
-        self.iface.removeEntry(self.handle, self.folder, key, self.appid)
+        self.iface.removeEntry(self.handle, service, username, self.appid)

--- a/keyring/tests/backends/test_kwallet.py
+++ b/keyring/tests/backends/test_kwallet.py
@@ -5,9 +5,12 @@ from keyring.backends import kwallet
 from ..util import random_string
 from ..test_backend import BackendBasicTests
 
-
 @unittest.skipUnless(kwallet.DBusKeyring.viable, "Need DBus")
 class DBusKWalletTestCase(BackendBasicTests, unittest.TestCase):
+
+    # Remove '@' from service name as this is not supported in service names
+    # '@' will cause troubles during migration of kwallet entries
+    DIFFICULT_CHARS = BackendBasicTests.DIFFICULT_CHARS.replace('@', '')
 
     def init_keyring(self):
         return kwallet.DBusKeyring()

--- a/keyring/tests/backends/test_kwallet.py
+++ b/keyring/tests/backends/test_kwallet.py
@@ -1,6 +1,8 @@
+import string
 import unittest
 
 from keyring.backends import kwallet
+from ..util import random_string
 from ..test_backend import BackendBasicTests
 
 
@@ -9,3 +11,55 @@ class DBusKWalletTestCase(BackendBasicTests, unittest.TestCase):
 
     def init_keyring(self):
         return kwallet.DBusKeyring()
+
+    def tearDown(self):
+        for item in self.credentials_created:
+            # Suppress errors, as only one pre/post migration item will be present
+            try:
+                self.keyring.delete_password(*item)
+            except:
+                pass
+
+        # TODO Remove empty folders created during tests
+
+    def set_password(self, service, username, password, old_format=False):
+        # set the password and save the result so the test runner can clean
+        #  up after if necessary.
+        self.credentials_created.add((service, username))
+
+        if old_format:
+            username = username+'@'+service
+            service = 'Python'
+
+        super(DBusKWalletTestCase, self).set_password(service, username, password)
+
+    def check_set_get(self, service, username, password):
+        keyring = self.keyring
+
+        # for the non-existent password
+        self.assertEqual(keyring.get_password(service, username), None)
+
+        # common usage
+        self.set_password(service, username, password, True)
+        # re-init keyring to force migration
+        self.keyring = keyring = self.init_keyring()
+        ret_password = keyring.get_password(service, username)
+        self.assertEqual(
+                ret_password, password,
+                "Incorrect password for username: '%s' on service: '%s'. '%s' != '%s'"
+                % (service, username, ret_password, password))
+
+        # for the empty password
+        self.set_password(service, username, "", True)
+        # re-init keyring to force migration
+        self.keyring = keyring = self.init_keyring()
+        ret_password = keyring.get_password(service, username)
+        self.assertEqual(
+                ret_password, "",
+                "Incorrect password for username: '%s' on service: '%s'. '%s' != '%s'"
+                % (service, username, ret_password, ""))
+        ret_password = keyring.get_password('Python', username+'@'+service)
+        self.assertEqual(
+                ret_password, None,
+                "Not 'None' password returned for username: '%s' on service: '%s'. '%s' != '%s'. Passwords from old folder should be deleted during migration."
+                % (service, username, ret_password, None))

--- a/keyring/tests/test_backend.py
+++ b/keyring/tests/test_backend.py
@@ -14,9 +14,6 @@ from keyring.util import escape
 from .util import random_string
 from keyring import errors
 
-# Remove '@' from service name as this is not supported in service names
-# '@' will cause troubles during migration of kwallet entries
-DIFFICULT_CHARS = string.whitespace + string.punctuation.replace('@', '')
 # unicode only characters
 # Sourced from The Quick Brown Fox... Pangrams
 # http://www.columbia.edu/~fdc/utf8/
@@ -33,6 +30,8 @@ assert min(ord(char) for char in UNICODE_CHARS) > 127
 class BackendBasicTests(object):
     """Test for the keyring's basic functions. password_set and password_get
     """
+
+    DIFFICULT_CHARS = string.whitespace + string.punctuation
 
     def setUp(self):
         self.keyring = self.init_keyring()
@@ -69,30 +68,30 @@ class BackendBasicTests(object):
         self.check_set_get(service, username, password)
 
     def test_difficult_chars(self):
-        password = random_string(20, DIFFICULT_CHARS)
-        username = random_string(20, DIFFICULT_CHARS)
-        service = random_string(20, DIFFICULT_CHARS)
+        password = random_string(20, self.DIFFICULT_CHARS)
+        username = random_string(20, self.DIFFICULT_CHARS)
+        service = random_string(20, self.DIFFICULT_CHARS)
         self.check_set_get(service, username, password)
 
     def test_delete_present(self):
-        password = random_string(20, DIFFICULT_CHARS)
-        username = random_string(20, DIFFICULT_CHARS)
-        service = random_string(20, DIFFICULT_CHARS)
+        password = random_string(20, self.DIFFICULT_CHARS)
+        username = random_string(20, self.DIFFICULT_CHARS)
+        service = random_string(20, self.DIFFICULT_CHARS)
         self.keyring.set_password(service, username, password)
         self.keyring.delete_password(service, username)
         self.assertIsNone(self.keyring.get_password(service, username))
 
     def test_delete_not_present(self):
-        username = random_string(20, DIFFICULT_CHARS)
-        service = random_string(20, DIFFICULT_CHARS)
+        username = random_string(20, self.DIFFICULT_CHARS)
+        service = random_string(20, self.DIFFICULT_CHARS)
         self.assertRaises(errors.PasswordDeleteError,
             self.keyring.delete_password, service, username)
 
     def test_delete_one_in_group(self):
-        username1 = random_string(20, DIFFICULT_CHARS)
-        username2 = random_string(20, DIFFICULT_CHARS)
-        password  = random_string(20, DIFFICULT_CHARS)
-        service   = random_string(20, DIFFICULT_CHARS)
+        username1 = random_string(20, self.DIFFICULT_CHARS)
+        username2 = random_string(20, self.DIFFICULT_CHARS)
+        password  = random_string(20, self.DIFFICULT_CHARS)
+        service   = random_string(20, self.DIFFICULT_CHARS)
         self.keyring.set_password(service, username1, password)
         self.set_password(service, username2, password)
         self.keyring.delete_password(service, username1)
@@ -107,7 +106,7 @@ class BackendBasicTests(object):
 
     def test_unicode_and_ascii_chars(self):
         source = (random_string(10, UNICODE_CHARS) + random_string(10) +
-                 random_string(10, DIFFICULT_CHARS))
+                 random_string(10, self.DIFFICULT_CHARS))
         password = random_string(20, source)
         username = random_string(20, source)
         service = random_string(20, source)

--- a/keyring/tests/test_backend.py
+++ b/keyring/tests/test_backend.py
@@ -14,7 +14,9 @@ from keyring.util import escape
 from .util import random_string
 from keyring import errors
 
-DIFFICULT_CHARS = string.whitespace + string.punctuation
+# Remove '@' from service name as this is not supported in service names
+# '@' will cause troubles during migration of kwallet entries
+DIFFICULT_CHARS = string.whitespace + string.punctuation.replace('@', '')
 # unicode only characters
 # Sourced from The Quick Brown Fox... Pangrams
 # http://www.columbia.edu/~fdc/utf8/


### PR DESCRIPTION
This is a continuation of work from issue #83.

I rewrote all from scratch. Since last time KWallet backend was rewritten to use DBus, so most of the changes was not mergeable.

Please review.
