### PR TITLE
require dbus-python and secretstorage on linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ test_requirements = [
     'pytest>=2.8',
 ]
 
+linux_requirements = [
+    # dbus-python is a declared req only by some versions of secretstorage
+    "dbus-python",
+    "secretstorage"
+]
+
 setup_params = dict(
     name='keyring',
     use_scm_version=True,
@@ -38,6 +44,7 @@ setup_params = dict(
     extras_require={
         'test': test_requirements,
         ':sys_platform=="win32"': ['pywin32-ctypes'],
+        ':platform_system=="Linux"': linux_requirements,
     },
     setup_requires=[
         'setuptools_scm>=1.9',


### PR DESCRIPTION
This PR installs dbus-python and secretstorage on linux.

I test it with:

```
pip install -e git+https://github.com/reece/keyring@231-require-secretstorage-on-linux#egg=keyring
```

I did _not_ test it on other platforms, which should probably be done just to make sure it didn't foul up non-linux platforms. (Obviously, not expected.)

I intentionally left the current docs untouched because they might be referenced by folks on previous versions for the near future.
