### PR TITLE
closes #231: require dbus-python and secretstorage on linux

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,2 +1,11 @@
+syntax: glob
+
+*.bak
+*.egg-info
+*.orgin
+*~
+.eggs
+__pycache__
 build
 dist
+ve

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ test_requirements = [
     'pytest>=2.8',
 ]
 
+linux_requirements = [
+    # dbus-python is a declared req only by some versions of secretstorage
+    "dbus-python",
+    "secretstorage"
+]
+
 setup_params = dict(
     name='keyring',
     use_scm_version=True,
@@ -38,6 +44,8 @@ setup_params = dict(
     extras_require={
         'test': test_requirements,
         ':sys_platform=="win32"': ['pywin32-ctypes'],
+        ':sys_platform=="linux2"': linux_requirements,  # python 2
+        ':sys_platform=="linux"': linux_requirements,   # python 3
     },
     setup_requires=[
         'setuptools_scm>=1.9',


### PR DESCRIPTION
Whoops... somehow PR'd the wrong commit last time 'round (even though I tested the right one!).

Tested like so:

```
snafu$ mkvirtualenv t2
Running virtualenv with interpreter /usr/bin/python2
New python executable in /home/reece/.virtualenvs/t2/bin/python2
Also creating executable in /home/reece/.virtualenvs/t2/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
# hg: reece / default / 539f31b35dd8 / 98 [!//▾/▴]
(t2) snafu$ pip install -e git+https://github.com/reece/keyring@231-require-secretstorage-on-linux#egg=keyring
Obtaining keyring from git+https://github.com/reece/keyring@231-require-secretstorage-on-linux#egg=keyring
  Cloning https://github.com/reece/keyring (to 231-require-secretstorage-on-linux) to ./.virtualenvs/t2/src/keyring
Collecting dbus-python (from keyring)
  Using cached dbus-python-1.2.4.tar.gz
Collecting secretstorage (from keyring)
  Using cached SecretStorage-2.2.0.tar.gz
Collecting pycrypto (from secretstorage->keyring)
  Using cached pycrypto-2.6.1.tar.gz
Building wheels for collected packages: dbus-python, secretstorage, pycrypto
  Running setup.py bdist_wheel for dbus-python ... done
  Stored in directory: /home/reece/.cache/pip/wheels/b2/b5/8f/008366d0f3ca5b1dd74be931fde265aca2042a5ae292d9b31d
  Running setup.py bdist_wheel for secretstorage ... done
  Stored in directory: /home/reece/.cache/pip/wheels/7b/ef/8e/b2ebfb4a7bf02a4200c2734c4e3010cfc65e960b806629eb38
  Running setup.py bdist_wheel for pycrypto ... done
  Stored in directory: /home/reece/.cache/pip/wheels/80/1f/94/f76e9746864f198eb0e304aeec319159fa41b082f61281ffce
Successfully built dbus-python secretstorage pycrypto
Installing collected packages: dbus-python, pycrypto, secretstorage, keyring
  Running setup.py develop for keyring
Successfully installed dbus-python-1.2.4 keyring pycrypto-2.6.1 secretstorage-2.2.0
# hg: reece / default / 539f31b35dd8 / 98 [!//▾/▴]
(t2) snafu$ python -c "import keyring; print(keyring.get_keyring())"
<keyring.backends.SecretService.Keyring object at 0x7fd71c537710>

```
