### PR TITLE
README.rst: Rename link so there are not 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Linux
 On Linux, the recommended keyring relies on SecretStorage, which in
 turn relies on dbus-python, but dbus-python does not install correctly
 when using the Python installers, so dbus-python must be installed
-as a system package. See `SecretStorage
+as a system package. See `the SecretStorage GitHub repo
 <https://github.com/mitya57/secretstorage>`_ for details.
 
 -------------


### PR DESCRIPTION
Renamed `secretstorage` link so there are not 2 links with the same name. This eliminates the following warning that I was getting:

```
$ pip install restview
$ restview --strict --pypi-strict README.rst
README.rst:3: (WARNING/2) Duplicate explicit target name: "secretstorage".
```

This may or may not fix the issue that [PyPI](https://pypi.python.org/pypi/keyring) is rendering the readme as text rather than as reST.
