### PR TITLE
Add absolute_import

### DIFF
--- a/keyring/core.py
+++ b/keyring/core.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 """
 Core API functions and initialization routines.
 """


### PR DESCRIPTION
In Python 2.x after I upgraded to the latest keyring library I started getting import failures from inside core.py. It cannot find backend.
