### PR TITLE
SecretStorage: add an option to specify custom collection path, and use that in tests

### DIFF
--- a/keyring/tests/backends/test_SecretService.py
+++ b/keyring/tests/backends/test_SecretService.py
@@ -12,7 +12,9 @@ class SecretServiceKeyringTestCase(BackendBasicTests, unittest.TestCase):
     def init_keyring(self):
         print("Testing SecretServiceKeyring; the following "
             "password prompts are for this keyring")
-        return SecretService.Keyring()
+        keyring = SecretService.Keyring()
+        keyring.preferred_collection = '/org/freedesktop/secrets/collection/session'
+        return keyring
 
 class SecretServiceKeyringUnitTests(unittest.TestCase):
     def test_supported_no_secretstorage(self):


### PR DESCRIPTION
A session collection is temporary and is stored in the server process memory. Using it allows us to run tests when the default collection does not exist.

I use a similar patch in Debian packaging, and it allows us to run the tests with Secret Service backend in an automated manner, see [Debian logs](https://ci.debian.net/packages/p/python-keyring/unstable/amd64/) or [Ubuntu logs](http://autopkgtest.ubuntu.com/packages/python-keyring) (which have five different architectures).