### PR TITLE
Reflect the KDE evolution in the class hierarchy, but keep the priority

### DIFF
--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -13,27 +13,12 @@ except ImportError:
 
 class DBusKeyring(KeyringBackend):
     """
-    KDE KWallet 5 via D-Bus
+    KDE KWallet 4 via D-Bus
     """
 
     appid = 'Python program'
-    wallet = None
-    bus_name = 'org.kde.kwalletd5'
-    object_path = '/modules/kwalletd5'
-
-    @classmethod
-    def _select_wallet(cls, bus):
-        if cls.wallet is not None:
-            return cls.wallet
-
-        for bus_name, object_path in cls._wallet_objects:
-            try:
-                proxy = bus.get_object(bus_name, object_path)
-            except dbus.DBusException:
-                pass
-            else:
-                cls.wallet = proxy
-                return proxy
+    bus_name = 'org.kde.kwalletd'
+    object_path = '/modules/kwalletd'
 
     @properties.ClassProperty
     @classmethod
@@ -50,7 +35,7 @@ class DBusKeyring(KeyringBackend):
             tmpl = 'cannot connect to {bus_name}'
             msg = tmpl.format(bus_name=cls.bus_name)
             raise RuntimeError(msg)
-        return 4.9
+        return 3.9
 
     def __init__(self, *arg, **kw):
         super(DBusKeyring, self).__init__(*arg, **kw)
@@ -127,15 +112,16 @@ class DBusKeyring(KeyringBackend):
         self.iface.removeEntry(self.handle, service, username, self.appid)
 
 
-class DBusKeyringKWallet4(DBusKeyring):
+class DBusKeyringKWallet5(DBusKeyring):
     """
-    KDE KWallet 4 via D-Bus
+    KDE KWallet 5 via D-Bus
     """
 
-    bus_name = 'org.kde.kwalletd'
-    object_path = '/modules/kwalletd'
+    bus_name = 'org.kde.kwalletd5'
+    object_path = '/modules/kwalletd5'
 
     @properties.ClassProperty
     @classmethod
     def priority(cls):
-        return super(DBusKeyringKWallet4, cls).priority - 1
+        # prefer KWallet5 over KWallet4
+        return super(DBusKeyringKWallet5, cls).priority + 1

--- a/keyring/tests/backends/test_kwallet.py
+++ b/keyring/tests/backends/test_kwallet.py
@@ -4,7 +4,7 @@ from keyring.backends import kwallet
 from ..test_backend import BackendBasicTests
 
 
-@unittest.skipUnless(kwallet.DBusKeyring.viable, "KWallet5 unavailable")
+@unittest.skipUnless(kwallet.DBusKeyring.viable, "KWallet4 unavailable")
 class DBusKWalletTestCase(BackendBasicTests, unittest.TestCase):
 
     # Remove '@' from service name as this is not supported in service names
@@ -67,8 +67,8 @@ class DBusKWalletTestCase(BackendBasicTests, unittest.TestCase):
                 % (service, username, ret_password, None))
 
 
-@unittest.skipUnless(kwallet.DBusKeyringKWallet4.viable,
-    "KWallet4 unavailable")
-class DBusKWallet4TestCase(DBusKWalletTestCase):
+@unittest.skipUnless(kwallet.DBusKeyringKWallet5.viable,
+    "KWallet5 unavailable")
+class DBusKWallet5TestCase(DBusKWalletTestCase):
     def init_keyring(self):
-        return kwallet.DBusKeyringKWallet4()
+        return kwallet.DBusKeyringKWallet5()


### PR DESCRIPTION
Get this in line with the usual KDE nomenclature, that adds a 5 for KDE Framework 5 elements, similar to the bus names and object paths. This way, I find it less confusing. Anyway, the priority order is kept. 
While at it, remove unused code.

I checked your changes and this one too for both environments, and it acts as advertised.
I love this code more than ever before... ;) Okay, okay, I'm in touch with it for a day now... :)

Cheers,
Pete