### PR TITLE
Add hook for supplying password to devpi-client.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+10.3
+----
+
+* #264: Implement devpi hook for supplying a password when
+  logging in with `devpi <https://pypi.org/project/devpi>`_
+  client.
+
 10.2
 ----
 

--- a/conftest.py
+++ b/conftest.py
@@ -6,3 +6,5 @@ collect_ignore = [
 
 if platform.system() != 'Darwin':
 	collect_ignore.append('keyring/backends/_OS_X_API.py')
+
+collect_ignore.append('keyring/devpi_client.py')

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,0 +1,10 @@
+from pluggy import HookimplMarker
+
+import keyring
+
+
+hookimpl = HookimplMarker("devpiclient")
+
+@hookimpl()
+def devpiclient_get_password(url, username):
+	return keyring.get_password(url, username)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ params = dict(
         'console_scripts': [
             'keyring=keyring.cli:main',
         ],
+        'devpi_client': [
+            'keyring = keyring.devpi_client',
+        ],
     },
 )
 if __name__ == '__main__':


### PR DESCRIPTION
Attempts to implement interface proposed in https://bitbucket.org/hpk42/devpi/pull-requests/397.

@fschulze, does this look like it would do what you expect? Would a `None` return from `devpiclient_get_password` defer to another plugin?