### PR TITLE
Make util.escape.unescape tolerant to lowercase conversions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+10.3.1
+------
+
+* #267: More leniently unescape lowercased characters as
+  they get re-cased by ConfigParser.
+
 10.3
 ----
 

--- a/keyring/util/escape.py
+++ b/keyring/util/escape.py
@@ -55,6 +55,6 @@ def unescape(value):
     """
     re_esc = re.compile(
         # the pattern must be bytes to operate on bytes
-        ESCAPE_FMT.replace('%02X', '(?P<code>[0-9A-F]{2})').encode('ascii')
+        ESCAPE_FMT.replace('%02X', '(?P<code>[0-9A-Fa-f]{2})').encode('ascii')
     )
     return re_esc.sub(_unescape_code, value.encode('ascii')).decode('utf-8')


### PR DESCRIPTION
util.escape.escape() is most prominently used for config file items.
Unfortunately, ConfigParser has a really bad habit of lowercasing
the keys by default with the optionxform() method.

escape() transforms everything except ascii letters and digits to
a _%02X sequence, and unescape() tries to revert this transformation,
but does not take the lowercasing into account, resulting in a
incomplete revert.
```python
>>> from keyring.util.escape import escape, unescape
>>> unescape(escape('username@example.com:443').lower())
'username@example_2ecom_3a443'
```

Since unescape isn't used in the code, the risk of breaking something
is quite low.