### PR TITLE
Link to keyring_jeepney backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,9 @@ use-cases. Simply install them to make them available:
 - `keyrings.alt <https://pypi.org/project/keyrings.alt>`_ - "alternate",
   less common backends, originally part of the core package, but now
   available for opt-in.
+- `keyring_jeepney <https://pypi.python.org/pypi/keyring_jeepney>`__ - a
+  pure Python backend using the secret service DBus API for desktop
+  Linux.
 
 Write your own keyring backend
 ==============================


### PR DESCRIPTION
I wrote a pure Python DBus interface, which avoids some of the installation hassle with depending on the system dbus libraries.

This is not super robust so far - e.g. it assumes that the default keyring is already unlocked, which I think is typically true but not always. But I have checked that I can store, retrieve and delete a password, at least on my own machine.