### PR TITLE
Set the appid for SecretService & KWallet to something meaningful.

### DIFF
--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -1,5 +1,8 @@
 import logging
 
+import sys
+import os
+
 from ..util import properties
 from ..backend import KeyringBackend
 from ..errors import (InitError, PasswordDeleteError,
@@ -15,7 +18,7 @@ log = logging.getLogger(__name__)
 
 class Keyring(KeyringBackend):
     """Secret Service Keyring"""
-    appid = "python-keyring"
+    appid = os.path.basename(sys.argv[0]) or 'Python keyring library'
 
     @properties.ClassProperty
     @classmethod

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import sys
+import os
+
 from ..backend import KeyringBackend
 from ..errors import PasswordDeleteError
 from ..errors import PasswordSetError
@@ -17,7 +20,7 @@ class DBusKeyring(KeyringBackend):
     KDE KWallet 5 via D-Bus
     """
 
-    appid = 'Python program'
+    appid = os.path.basename(sys.argv[0]) or 'Python keyring library'
     wallet = None
     bus_name = 'org.kde.kwalletd5'
     object_path = '/modules/kwalletd5'


### PR DESCRIPTION
On KDE, e.g., the appid is displayed by the KWallet when it prompts the user to open a wallet.  So someting more meaningful than 'Python program' should be sent as the appid.