### PR TITLE
Remove usage of pkg_resources, which has huge import overhead.

### DIFF
--- a/keyring/__init__.py
+++ b/keyring/__init__.py
@@ -4,12 +4,6 @@ from .core import (set_keyring, get_keyring, set_password, get_password,
                    delete_password)
 from .getpassbackend import get_password as get_pass_get_password
 
-try:
-    import pkg_resources
-    __version__ = pkg_resources.get_distribution('keyring').version
-except Exception:
-    __version__ = 'unknown'
-
 __all__ = (
     'set_keyring', 'get_keyring', 'set_password', 'get_password',
     'delete_password', 'get_pass_get_password',


### PR DESCRIPTION
See: https://github.com/pypa/setuptools/issues/926

Providing this via #197 was a mistake. Let the caller figure it out.