### PR TITLE
Use 'entrypoints' instead of pkg_resources to avoid import time overhead.

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -9,7 +9,7 @@ import logging
 import importlib
 
 try:
-    import pkg_resources
+    import entrypoints
 except ImportError:
     pass
 
@@ -161,10 +161,10 @@ def _load_plugins():
 
     `initialize_func` is optional, but will be invoked if callable.
     """
-    if 'pkg_resources' not in globals():
+    if 'entrypoints' not in globals():
         return
     group = 'keyring.backends'
-    entry_points = pkg_resources.iter_entry_points(group=group)
+    entry_points = entrypoints.get_group_all(group=group)
     for ep in entry_points:
         try:
             log.info('Loading %s', ep.name)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ params = dict(
     ),
     python_requires='>=2.7',
     install_requires=[
+        'entrypoints',
     ],
     extras_require={
         'testing': [


### PR DESCRIPTION
Use 'entrypoints' instead of pkg_resources to avoid import time overhead.