### PR TITLE
BF: catch all exceptions not just Runtime when checking .priority

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -163,7 +163,7 @@ def get_all_keyring():
     def is_class_viable(keyring_cls):
         try:
             keyring_cls.priority
-        except RuntimeError:
+        except Exception:
             return False
         return True
 


### PR DESCRIPTION
Although it is a crude patch, imho as original #316 has shown, I do not see a reason why it should really catch only still not very specific RuntimeError

Fixes #316 (at least for my case)