### PR TITLE
setup.py: Install SecretStorage 2.x for Python older than 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,12 @@ params = dict(
         ':sys_platform=="win32"': [
             'pywin32-ctypes!=0.1.0,!=0.1.1',
         ],
-        ':sys_platform=="linux2" or sys_platform=="linux"': [
+        ':sys_platform=="linux" and python_version>="3.5"': [
             "secretstorage",
+        ],
+        ':(sys_platform=="linux2" or sys_platform=="linux")'
+        ' and python_version<"3.5"': [
+            "secretstorage<3",
         ],
     },
     setup_requires=[


### PR DESCRIPTION
This hack is only needed for pip versions older than 9.
Fixes #301, fixes #321.

@jaraco I have little experience in writing PEP 508 markers, so please review it.