### PR TITLE
bugfix: AttributeError: 'dict' object has no attribute 'unichr'

### DIFF
--- a/keyring/util/escape.py
+++ b/keyring/util/escape.py
@@ -23,7 +23,7 @@ else:
         return s.decode('utf-8')
 
     def _unichr(c):
-        return unichr(c)
+        return unichr(c)  # noqa: F821
 
 LEGAL_CHARS = (
     getattr(string, 'letters', None)  # Python 2

--- a/keyring/util/escape.py
+++ b/keyring/util/escape.py
@@ -23,7 +23,7 @@ else:
         return s.decode('utf-8')
 
     def _unichr(c):
-        return __builtins__.unichr(c)
+        return unichr(c)
 
 LEGAL_CHARS = (
     getattr(string, 'letters', None)  # Python 2


### PR DESCRIPTION
Hello,

My users (Python 2) have started getting this crash after upgrading yesterday to keyring 12.1.0 (from 10.4.0):

```
  File ".../lib/python2.7/site-packages/keyring/util/escape.py", line 27, in _unichr
    return __builtins__.unichr(c)
AttributeError: 'dict' object has no attribute 'unichr'
```

It seems like 09c9008d7c71a2fb83264e9eeefa4f5c0daa9ae8 broke something. I confirmed that this PR fixes it for me.

I wish I knew why _exactly_ this is a problem, because the new form seems correct, and if I open up an interpreter and do a `dir(__builtins__)`, `unichr` is in there. However, if I throw a print statement before the `def _unichr`, I see that somehow, in that module, `__builtins__` only contains this stuff:

```
['__class__', '__cmp__', '__contains__', '__delattr__', '__delitem__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__gt__', '__hash__', '__init__', '__iter__', '__le__', '__len__', '__lt__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__subclasshook__', 'clear', 'copy', 'fromkeys', 'get', 'has_key', 'items', 'iteritems', 'iterkeys', 'itervalues', 'keys', 'pop', 'popitem', 'setdefault', 'update', 'values', 'viewitems', 'viewkeys', 'viewvalues']
```

and `unichr` is missing.

So somehow, something in my pile of scripts is altering `__builtins__`? Not sure. Could be related to my attempts to be Py2/3 compatible through `__future__` imports  and the `futurize` library. But in any case, if folks are shadowing `unichr`, there's probably a reason for it, and we should just accept the new name, right?