### PR TITLE
Improve kwallet backend

### DIFF
--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -6,7 +6,7 @@ import os
 from ..util import properties
 from ..backend import KeyringBackend
 from ..errors import (InitError, PasswordDeleteError,
-                      ExceptionRaisedContext)
+                      ExceptionRaisedContext, KeyringLocked)
 
 try:
     import secretstorage
@@ -58,7 +58,7 @@ class Keyring(KeyringBackend):
         if collection.is_locked():
             collection.unlock()
             if collection.is_locked():  # User dismissed the prompt
-                raise InitError("Failed to unlock the collection!")
+                raise KeyringLocked("Failed to unlock the collection!")
         return collection
 
     def get_password(self, service, username):
@@ -71,7 +71,7 @@ class Keyring(KeyringBackend):
             if hasattr(item, 'unlock'):
                 item.unlock()
             if item.is_locked():  # User dismissed the prompt
-                raise InitError('Failed to unlock the item!')
+                raise KeyringLocked('Failed to unlock the item!')
             return item.get_secret().decode('utf-8')
 
     def set_password(self, service, username, password):

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -5,7 +5,7 @@ import os
 
 from ..backend import KeyringBackend
 from ..errors import PasswordDeleteError
-from ..errors import PasswordSetError, InitError
+from ..errors import PasswordSetError, InitError, KeyringLocked
 from ..util import properties
 
 try:
@@ -99,7 +99,7 @@ class DBusKeyring(KeyringBackend):
         """
         if not self.connected(service):
             # the user pressed "cancel" when prompted to unlock their keyring.
-            return None
+            raise KeyringLocked("Failed to unlock the keyring!")
         if not self.iface.hasEntry(self.handle, service, username, self.appid):
             return None
         password = self.iface.readPassword(

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -5,7 +5,7 @@ import os
 
 from ..backend import KeyringBackend
 from ..errors import PasswordDeleteError
-from ..errors import PasswordSetError
+from ..errors import PasswordSetError, InitError
 from ..util import properties
 
 try:
@@ -84,8 +84,9 @@ class DBusKeyring(KeyringBackend):
             self.iface = dbus.Interface(remote_obj, 'org.kde.KWallet')
             self.handle = self.iface.open(
                 self.iface.networkWallet(), wId, self.appid)
-        except dbus.DBusException:
-            self.handle = -1
+        except dbus.DBusException as e:
+            raise InitError('Failed to open keyring: %s.' % e)
+
         if self.handle < 0:
             return False
         self._migrate(service)

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -76,7 +76,9 @@ class DBusKeyring(KeyringBackend):
 
     def connected(self, service):
         if self.handle >= 0:
-            return True
+            if self.iface.isOpen(self.handle):
+                return True
+
         bus = dbus.SessionBus(mainloop=DBusGMainLoop())
         wId = 0
         try:

--- a/keyring/errors.py
+++ b/keyring/errors.py
@@ -21,6 +21,11 @@ class InitError(KeyringError):
     """
 
 
+class KeyringLocked(KeyringError):
+    """Raised when the keyring could not be initialised
+    """
+
+
 class ExceptionRaisedContext(object):
     """
     An exception-trapping context that indicates whether an exception was


### PR DESCRIPTION
If connected() returns on all exceptions False, applications have no way of knowing if the password is not in the keyring or an error has happened.

Fixes #327 


The wallet could have been closed after a while. Check if the wallet is
open before using it

Fixes #298