### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
 	# workaround for yaml/pyyaml#126
 	# git+https://github.com/yaml/pyyaml@master#egg=pyyaml;python_version=="3.7"
 commands =
-	py.test {posargs}
+	pytest {posargs}
 	python setup.py checkdocs
 usedevelop = True
 extras = testing


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot