### PR TITLE
Allow to set password from pipe

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -92,7 +92,7 @@ class CommandLineTool(object):
         if sys.stdin.isatty():
             return getpass.getpass(prompt)
         else:
-            return sys.stdin.readline().rstrip()
+            return sys.stdin.readline().rstrip('\n')
 
     def output_password(self, password):
         """Output the password to the user.

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -89,8 +89,10 @@ class CommandLineTool(object):
 
         This mostly exists to ease the testing process.
         """
-
-        return getpass.getpass(prompt)
+        if sys.stdin.isatty():
+            return getpass.getpass(prompt)
+        else:
+            return sys.stdin.readline().rstrip()
 
     def output_password(self, password):
         """Output the password to the user.


### PR DESCRIPTION
The usecase is to dump the output of a command into the keyring. For
example a random token is generated and must be stored.