### PR TITLE
Improve output of ‘keyring --list-backends’

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -73,6 +73,12 @@ class KeyringBackend(object):
         mod_name = mod_name.replace('_', ' ')
         return ' '.join([mod_name, cls.__name__])
 
+    def __str__(self):
+        keyring_class = type(self)
+        return ("%s.%s (priority: %g)" % (keyring_class.__module__,
+                                          keyring_class.__name__,
+                                          keyring_class.priority))
+
     @abc.abstractmethod
     def get_password(self, service, username):
         """Get password of the username for the service


### PR DESCRIPTION
Fixes #329.

Now the output looks like this:
```
keyrings.alt.file.PlaintextKeyring (priority: 0.5)
keyring.backends.SecretService.Keyring (priority: 5)
keyrings.alt.pyfs.KeyczarKeyring (priority: 2)
keyrings.alt.pyfs.PlaintextKeyring (priority: 2)
keyrings.alt.file.EncryptedKeyring (priority: 0.6)
keyring.backends.kwallet.DBusKeyringKWallet4 (priority: 3.9)
keyring.backends.kwallet.DBusKeyring (priority: 4.9)
keyring.backends.fail.Keyring (priority: 0)
```