### PR TITLE
Add Bitwarden-keyring to the external backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,10 @@ use-cases. Simply install them to make them available:
 - `gsheet-keyring <https://pypi.org/project/gsheet-keyring>`_
   - a backend that stores secrets in a Google Sheet. For use with
   `ipython-secrets <https://pypi.org/project/ipython-secrets>`_.
+- `bitwarden-keyring <https://pypi.org/project/bitwarden-keyring/0.1.0/>`_
+  - a backend that stores secrets in the `BitWarden <https://bitwarden.com/>`_
+  password manager.
+  
 
 Write your own keyring backend
 ==============================


### PR DESCRIPTION
I've uploaded the `bitwarden-keyring` package to PyPI using `twine`, that was using `keyring`, that was using `bitwarden-keyring` that allowed me not to type my PyPI password. Like they said in Star Wars, "Keyring is now complete" 🤣 

Apart from this, if you want to review the code of [the backend itself](https://github.com/ewjoachim/bitwarden-keyring), it's also highly appreciated.