### PR TITLE
Fixes #323 Race condition in Windows delete_password

### DIFF
--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -134,7 +134,6 @@ class WinVaultKeyring(KeyringBackend):
                 return
             raise
 
-
     def get_credential(self, service, username):
         res = None
         # get the credentials associated with the provided username

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -123,10 +123,17 @@ class WinVaultKeyring(KeyringBackend):
             raise PasswordDeleteError(service)
 
     def _delete_password(self, target):
-        win32cred.CredDelete(
-            Type=win32cred.CRED_TYPE_GENERIC,
-            TargetName=target,
-        )
+        try:
+            win32cred.CredDelete(
+                Type=win32cred.CRED_TYPE_GENERIC,
+                TargetName=target,
+            )
+        except pywintypes.error as e:
+            e = OldPywinError.wrap(e)
+            if e.winerror == 1168 and e.funcname == 'CredDelete':  # not found
+                return
+            raise
+
 
     def get_credential(self, service, username):
         res = None


### PR DESCRIPTION
Just made the simplest possible fix, following the pattern from `get_password`.

I don't see any value in raising an error deleting a password that was just deleted, as the result is exactly what was intended, and losing a deletion race isn't a good enough reason to bother the user.