### PR TITLE
Restore low-priority (0, 1) backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+16.0.1
+------
+
+* #357: Once again allow all positive, non-zero priority
+  keyrings to participate.
+
 16.0.0
 ------
 

--- a/conftest.py
+++ b/conftest.py
@@ -8,3 +8,14 @@ if platform.system() != 'Darwin':
     collect_ignore.append('keyring/backends/_OS_X_API.py')
 
 collect_ignore.append('keyring/devpi_client.py')
+
+
+def pytest_configure():
+        workaround_sugar_issue_159()
+
+
+def workaround_sugar_issue_159():
+    "https://github.com/Frozenball/pytest-sugar/159"
+    import pytest_sugar
+    pytest_sugar.SugarTerminalReporter.pytest_runtest_logfinish = \
+        lambda self: None

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -11,6 +11,14 @@ from ..backend import KeyringBackend
 
 
 class ChainerBackend(KeyringBackend):
+    """
+    >>> ChainerBackend(())
+    <keyring.backends.chainer.ChainerBackend object at ...>
+    """
+
+    priority = 0
+    viable = False
+
     def __init__(self, backends):
         self.backends = list(backends)
 

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -88,11 +88,15 @@ def _create_chained_backend(keyrings):
     If one keyring is available, returns it. If more than one, returns a
     single keyring that chains them. If no keyrings, returns None.
     """
-    keyrings = sorted(keyrings, key=by_priority, reverse=True)
-    if keyrings:
-        if len(keyrings) == 1:
-            return keyrings[0]
-        return ChainerBackend(keyrings)
+    allowed = (
+        keyring for keyring in keyrings
+        if keyring.priority > 0
+    )
+    resolved = sorted(allowed, key=by_priority, reverse=True)
+    if resolved:
+        if len(resolved) == 1:
+            return resolved[0]
+        return ChainerBackend(resolved)
 
 
 def init_backend(limit=None):

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -88,8 +88,7 @@ def _create_chained_backend(keyrings):
     If one keyring is available, returns it. If more than one, returns a
     single keyring that chains them. If no keyrings, returns None.
     """
-    keyrings = sorted((k for k in keyrings if k.priority >= 1),
-                      key=by_priority, reverse=True)
+    keyrings = sorted(keyrings, key=by_priority, reverse=True)
     if keyrings:
         if len(keyrings) == 1:
             return keyrings[0]


### PR DESCRIPTION
In #357, we learned that low priority backends are now being excluded from use. That was not an intended change. I think I imagined that only the chainer would be affected, but because the chainer is now in place as the default mechanism for resolving backends, it had the effect of excluding the non-recommended backends.

This change restores support for non-recommended backends.

I think the main reason for adding the limit was to prevent the fail.Keyring from being included, so in this change, backends with a priority of 0 are still excluded from the chained backends.