### PR TITLE
Implement Chainer as normal backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+16.1.0
+------
+
+* Refactor ChainerBackend, introduced in 16.0 to function
+  as any other backend, activating when relevant.
+
 16.0.2
 ------
 

--- a/keyring/tests/backends/test_chainer.py
+++ b/keyring/tests/backends/test_chainer.py
@@ -1,0 +1,37 @@
+import pytest
+
+import keyring.backends.chainer
+from keyring import backend
+
+
+@pytest.fixture
+def two_keyrings(monkeypatch):
+    def get_two():
+        class Keyring1(backend.KeyringBackend):
+            priority = 1
+
+            def get_password(self, system, user):
+                return 'ring1-{system}-{user}'.format(**locals())
+
+            def set_password(self, system, user, password):
+                pass
+
+        class Keyring2(backend.KeyringBackend):
+            priority = 2
+
+            def get_password(self, system, user):
+                return 'ring2-{system}-{user}'.format(**locals())
+
+            def set_password(self, system, user, password):
+                raise NotImplementedError()
+
+        return Keyring1(), Keyring2()
+
+    monkeypatch.setattr('keyring.backend.get_all_keyring', get_two)
+
+
+class TestChainer:
+    def test_chainer_gets_from_highest_priority(self, two_keyrings):
+        chainer = keyring.backends.chainer.ChainerBackend()
+        pw = chainer.get_password('alpha', 'bravo')
+        assert pw == 'ring2-alpha-bravo'

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,4 @@ keyring.backends =
 	macOS = keyring.backends.OS_X
 	SecretService = keyring.backends.SecretService
 	KWallet = keyring.backends.kwallet
+	chainer = keyring.backends.chainer


### PR DESCRIPTION
In these changes, I revert all of the changes to the 'core' module from the original introduction of the ChainerBackend and instead implement the backend as any other discoverable backend, giving it the behaviors that give it priority when there are multiple backends suitable for chaining, but having it defer to other (by way of a 0 priority) when there are not chainable backends.

cc @zooba (FYI)