### PR TITLE
In ChainerBackend, honor any limit that might have been set during init_backend.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+17.1.0
+------
+
+* #366: When calling ``keyring.core.init_backend``, if any
+  limit function is supplied, it is saved and later honored by
+  the ``ChainerBackend`` as well.
+
 17.0.0
 ------
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -19,6 +19,10 @@ __metaclass__ = type
 log = logging.getLogger(__name__)
 
 
+by_priority = operator.attrgetter('priority')
+_limit = None
+
+
 class KeyringBackendMeta(abc.ABCMeta):
     """
     A metaclass that's both an ABCMeta and a type that keeps a registry of

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -5,8 +5,6 @@ discover passwords in each.
 
 from __future__ import absolute_import
 
-import operator
-
 from .. import backend
 from ..util import properties
 
@@ -35,17 +33,14 @@ class ChainerBackend(backend.KeyringBackend):
         """
         Discover all keyrings for chaining.
         """
-        # copy of keyring.core.by_priority, avoiding circular import
-        # on Python 3.4
-        # https://github.com/jaraco/keyring/issues/362
-        by_priority = operator.attrgetter('priority')
+        from .. import core
         allowed = (
             keyring
-            for keyring in backend.get_all_keyring()
+            for keyring in filter(core._limit, backend.get_all_keyring())
             if not isinstance(keyring, ChainerBackend)
             and keyring.priority > 0
         )
-        return sorted(allowed, key=by_priority, reverse=True)
+        return sorted(allowed, key=core.by_priority, reverse=True)
 
     def get_password(self, service, username):
         for keyring in self.backends:

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -33,14 +33,13 @@ class ChainerBackend(backend.KeyringBackend):
         """
         Discover all keyrings for chaining.
         """
-        from .. import core
         allowed = (
             keyring
-            for keyring in filter(core._limit, backend.get_all_keyring())
+            for keyring in filter(backend._limit, backend.get_all_keyring())
             if not isinstance(keyring, ChainerBackend)
             and keyring.priority > 0
         )
-        return sorted(allowed, key=core.by_priority, reverse=True)
+        return sorted(allowed, key=backend.by_priority, reverse=True)
 
     def get_password(self, service, username):
         for keyring in self.backends:

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -18,6 +18,7 @@ from .backends import fail
 log = logging.getLogger(__name__)
 
 _keyring_backend = None
+_limit = None
 
 
 def set_keyring(keyring):
@@ -86,7 +87,14 @@ by_priority = operator.attrgetter('priority')
 def init_backend(limit=None):
     """
     Load a keyring specified in the config file or infer the best available.
+
+    Limit, if supplied, should be a callable taking a backend and returning
+    True if that backend should be included for consideration.
     """
+    # save the limit for the chainer to honor
+    globals().update(_limit=limit)
+
+    # get all keyrings passing the limit filter
     keyrings = filter(limit, backend.get_all_keyring())
 
     set_keyring(

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -5,7 +5,6 @@ Core API functions and initialization routines.
 import os
 import sys
 import logging
-import operator
 
 from .py27compat import configparser, filter
 from .py33compat import max
@@ -18,7 +17,6 @@ from .backends import fail
 log = logging.getLogger(__name__)
 
 _keyring_backend = None
-_limit = None
 
 
 def set_keyring(keyring):
@@ -81,9 +79,6 @@ def recommended(backend):
     return backend.priority >= 1
 
 
-by_priority = operator.attrgetter('priority')
-
-
 def init_backend(limit=None):
     """
     Load a keyring specified in the config file or infer the best available.
@@ -92,7 +87,7 @@ def init_backend(limit=None):
     True if that backend should be included for consideration.
     """
     # save the limit for the chainer to honor
-    globals().update(_limit=limit)
+    backend._limit = limit
 
     # get all keyrings passing the limit filter
     keyrings = filter(limit, backend.get_all_keyring())
@@ -100,7 +95,7 @@ def init_backend(limit=None):
     set_keyring(
         load_env()
         or load_config()
-        or max(keyrings, default=fail.Keyring(), key=by_priority)
+        or max(keyrings, default=fail.Keyring(), key=backend.by_priority)
     )
 
 


### PR DESCRIPTION
Fixes #366.