### PR TITLE
add license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+


### PR DESCRIPTION
@jaraco I was messing around with this cool project called [raimon49/pip-licenses](https://github.com/raimon49/pip-licenses) tonight and found that this project shows up with license UNKNOWN when it is actually MIT.

I think this is because `pip-licenses` scans the license files bundled with packages you've installed in to `site-packages/` and you are not currently bundling your license file with your package on PyPi.

I hope you'll consider this PR to add the license to your source distribution.