### PR TITLE
minimum needed to control windows roaming

### DIFF
--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -83,23 +83,23 @@ class WinVaultKeyring(KeyringBackend):
             raise
         return res
 
-    def set_password(self, service, username, password):
+    def set_password(self, service, username, password, persist_type=win32cred.CRED_PERSIST_ENTERPRISE):
         existing_pw = self._get_password(service)
         if existing_pw:
             # resave the existing password using a compound target
             existing_username = existing_pw['UserName']
             target = self._compound_name(existing_username, service)
             self._set_password(target, existing_username,
-                               existing_pw['CredentialBlob'].decode('utf-16'))
-        self._set_password(service, username, text_type(password))
+                               existing_pw['CredentialBlob'].decode('utf-16'), persist_type)
+        self._set_password(service, username, text_type(password), persist_type)
 
-    def _set_password(self, target, username, password):
+    def _set_password(self, target, username, password, persist_type):
         credential = dict(Type=win32cred.CRED_TYPE_GENERIC,
                           TargetName=target,
                           UserName=username,
                           CredentialBlob=password,
                           Comment="Stored using python-keyring",
-                          Persist=win32cred.CRED_PERSIST_ENTERPRISE)
+                          Persist=persist_type)
         win32cred.CredWrite(credential, 0)
 
     def delete_password(self, service, username):

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -57,10 +57,10 @@ def get_password(service_name, username):
     return _keyring_backend.get_password(service_name, username)
 
 
-def set_password(service_name, username, password):
+def set_password(service_name, username, password, **backend_opts):
     """Set password for the user in the specified service.
     """
-    _keyring_backend.set_password(service_name, username, password)
+    _keyring_backend.set_password(service_name, username, password, **backend_opts)
 
 
 def delete_password(service_name, username):


### PR DESCRIPTION
This is a minimal solution.   It requires the user to know about the issue and choose to address it in a platform specific if block.

https://github.com/jaraco/keyring/issues/382

Until there are many such options, having an options framework may be overkill.