### PR TITLE
Made username optional with get commands

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -127,9 +127,10 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
         returned username.
         """
         # The default implementation requires a username here.
-        cred = self.get_password(service, username)
-        if cred['password'] is not None:
-            return credentials.SimpleCredential(cred['username'], cred['password'])
+        if username is not None:
+            password = self.get_password(service, username)
+            if password is not None:
+                return credentials.SimpleCredential(username, password)
         return None
 
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -127,10 +127,9 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
         returned username.
         """
         # The default implementation requires a username here.
-        if username is not None:
-            password = self.get_password(service, username)
-            if password is not None:
-                return credentials.SimpleCredential(username, password)
+        cred = self.get_password(service, username)
+        if cred['password'] is not None:
+            return credentials.SimpleCredential(cred['username'], cred['password'])
         return None
 
 

--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -46,21 +46,29 @@ class Keyring(KeyringBackend):
     def get_password(self, service, username):
         creds={}
         if (not username):
+            prompt = "find-generic-password"
+            
+            if (service.find(".com")):
+                prompt = "find-internet-password"
+            
             output = execute(
-                'security 2>&1 find-generic-password -g -s '+service,
-                lambda x: "",
-                lambda x: "",
-                ignore_exit_codes=True
-            )
+                    'security 2>&1 '+prompt+' -g -s '+service,
+                    lambda x: "",
+                    lambda x: "",
+                    ignore_exit_codes=True
+                )
 
             find_passwd = re.compile('password: "([^"]+)"').search
             find_user = re.compile('"acct"<blob>="([^"]+)"').search
             creds['username'] = find_key(find_user, output)
             creds['password'] = find_key(find_passwd, output)
-            
+
         else:
             try:
-                creds['password'] = api.find_generic_password(self.keychain, service, username)
+                if (service.find(".com")):
+                    creds['password'] = api.find_internet_password(self.keychain, service, username)
+                else:
+                    creds['password'] = api.find_generic_password(self.keychain, service, username)
                 creds['username'] = username
             except api.NotFound:
                 pass

--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -48,7 +48,7 @@ class Keyring(KeyringBackend):
         if (not username):
             prompt = "find-generic-password"
             
-            if (service.find(".com")):
+            if (service.find(".com")>=0):
                 prompt = "find-internet-password"
             
             output = execute(

--- a/keyring/backends/OS_X.py
+++ b/keyring/backends/OS_X.py
@@ -65,7 +65,7 @@ class Keyring(KeyringBackend):
 
         else:
             try:
-                if (service.find(".com")):
+                if (service.find(".com")>=0):
                     creds['password'] = api.find_internet_password(self.keychain, service, username)
                 else:
                     creds['password'] = api.find_generic_password(self.keychain, service, username)

--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -65,13 +65,17 @@ class Keyring(KeyringBackend):
         """Get password of the username for the service
         """
         collection = self.get_preferred_collection()
-        items = collection.search_items({"service": service})
+        if (not username):
+            items = collection.search_items({"service": service})
+        else:
+            items = collection.search_items({"service": service, "username": username})
         for item in items:
             if hasattr(item, 'unlock'):
                 item.unlock()
             if item.is_locked():  # User dismissed the prompt
                 raise KeyringLocked('Failed to unlock the item!')
-            return {"username":item.get_attributes()["username"],"password":item.get_secret().decode('utf-8')}
+
+            return {"username":username if username else item.get_attributes()["username"],"password":item.get_secret().decode('utf-8')}
 
     def set_password(self, service, username, password):
         """Set password for the username of the service

--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -65,13 +65,13 @@ class Keyring(KeyringBackend):
         """Get password of the username for the service
         """
         collection = self.get_preferred_collection()
-        items = collection.search_items({"username": username, "service": service})
+        items = collection.search_items({"service": service})
         for item in items:
             if hasattr(item, 'unlock'):
                 item.unlock()
             if item.is_locked():  # User dismissed the prompt
                 raise KeyringLocked('Failed to unlock the item!')
-            return item.get_secret().decode('utf-8')
+            return {"username":item.get_attributes()["username"],"password":item.get_secret().decode('utf-8')}
 
     def set_password(self, service, username, password):
         """Set password for the username of the service


### PR DESCRIPTION
On OS_X and SecretService, I've implemented some logic to make the username parameter optional in get_password/get_credential. Also the get password function on OS_X will check the service name to see if it should use find_generic or find_internet.