### PR TITLE
New feature - set properties from environment variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
+19.3.0
+------
+
+* Added new ``KeyringBackend.set_properties_from_env``.
+
 19.2.0
 ------
 
-* Add support for get_credential() with the SecretService backend
+* Add support for get_credential() with the SecretService backend.
 
 19.1.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,24 @@ Here's an example demonstrating how to invoke ``set_keyring``::
     print("password", keyring.get_password("demo-service", "tarek"))
 
 
+Altering Keyring Behavior
+=========================
+
+Keyring provides a mechanism to alter the keyring's behavior through
+environment variables. Each backend implements a
+``KeyringBackend.set_properties_from_env``, which
+when invoked will find all environment variables beginning with
+``KEYRING_PROPERTY_{NAME}`` and will set a property for each
+``{NAME.lower()}`` on the keyring. This method is invoked during
+initialization for the default/configured keyring.
+
+This mechanism may be used to set some useful values on various
+keyrings, including:
+
+- keychain; macOS, path to an alternate keychain file
+- appid; Linux/SecretService, alternate ID for the application
+
+
 Using Keyring on Ubuntu 16.04
 =============================
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -2,6 +2,7 @@
 Keyring implementation support
 """
 
+import os
 import abc
 import logging
 import operator
@@ -132,6 +133,18 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
             if password is not None:
                 return credentials.SimpleCredential(username, password)
         return None
+
+    def set_properties_from_env(self):
+        """For all KEYRING_PROPERTY_* env var, set that property."""
+
+        def parse(item):
+            key, value = item
+            pre, sep, name = key.partition('KEYRING_PROPERTY_')
+            return sep and (name.lower(), value)
+
+        props = filter(None, map(parse, os.environ.items()))
+        for name, value in props:
+            setattr(self, name, value)
 
 
 class Crypter:

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -24,6 +24,7 @@ def set_keyring(keyring):
     if not isinstance(keyring, backend.KeyringBackend):
         raise TypeError("The keyring must be a subclass of KeyringBackend")
     _keyring_backend = keyring
+    keyring.set_properties_from_env()
 
 
 def get_keyring():

--- a/keyring/tests/test_backend.py
+++ b/keyring/tests/test_backend.py
@@ -4,6 +4,7 @@
 Common test functionality for backends.
 """
 
+import os
 import string
 
 import pytest
@@ -159,3 +160,9 @@ class BackendBasicTests:
             ('user1', 'password1'),
             ('user2', 'password2'),
         )
+
+    def test_set_properties(self, monkeypatch):
+        env = dict(KEYRING_PROPERTY_FOO_BAR='fizz buzz', OTHER_SETTING='ignore me')
+        monkeypatch.setattr(os, 'environ', env)
+        self.keyring.set_properties_from_env()
+        assert self.keyring.foo_bar == 'fizz buzz'


### PR DESCRIPTION
In a few cases, I've observed the need for users to configure keyrings in the environment. In the macOS keyring, for example, the keychain path can be [configured in an environment variable](https://github.com/jaraco/keyring/blob/3f376c95ffabcfc86df5f9a4ef93c2f706df32d8/keyring/backends/OS_X.py#L20). This proposal generalizes that concept, allowing any keychain to solicit values from the environment in a `KEYRING_PROPERTY_{NAME}`.

It lowercases the portion after `KEYRING_PROPERTY_` and sets that property on the keyring instance during `init_backend`. It also can be called explicitly by any keyring explicitly constructed.

This behavior was inspired by [this comment](https://github.com/jaraco/keyring/pull/385#issuecomment-531545669) and the associated work there.