### PR TITLE
Don't import all keyrings unless necessary

### DIFF
--- a/keyring/core.py
+++ b/keyring/core.py
@@ -87,13 +87,12 @@ def init_backend(limit=None):
     # save the limit for the chainer to honor
     backend._limit = limit
 
-    # get all keyrings passing the limit filter
-    keyrings = filter(limit, backend.get_all_keyring())
-
     set_keyring(
         load_env()
         or load_config()
-        or max(keyrings, default=fail.Keyring(), key=backend.by_priority)
+        # get all keyrings passing the limit filter
+        or max(filter(limit, backend.get_all_keyring()),
+               default=fail.Keyring(), key=backend.by_priority)
     )
 
 

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -91,8 +91,11 @@ def init_backend(limit=None):
         load_env()
         or load_config()
         # get all keyrings passing the limit filter
-        or max(filter(limit, backend.get_all_keyring()),
-               default=fail.Keyring(), key=backend.by_priority)
+        or max(
+            filter(limit, backend.get_all_keyring()),
+            default=fail.Keyring(),
+            key=backend.by_priority,
+        )
     )
 
 


### PR DESCRIPTION
If a keyring is set in configuration or environment variables,
use that one and don't load all available keyrings.

Partially addresses https://github.com/jaraco/keyring/issues/403.