### PR TITLE
Fix log message formatting during exception handling

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -204,7 +204,7 @@ def _load_plugins():
             if callable(init_func):
                 init_func()
         except Exception:
-            log.exception("Error initializing plugin %s." % ep)
+            log.exception("Error initializing plugin %s." % ep.name)
 
 
 @util.once

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -204,7 +204,7 @@ def _load_plugins():
             if callable(init_func):
                 init_func()
         except Exception:
-            log.exception("Error initializing plugin %s." % ep.name)
+            log.exception("Error initializing plugin {ep}.".format(**locals()))
 
 
 @util.once


### PR DESCRIPTION
This fixes the log message by ensuring we only log the `EntryPoint` name. The root issue can be reproduced independently as shown below.

```sh
$ python -c 'from importlib.metadata import EntryPoint; "%s" % EntryPoint(name="name", value="value", group="group")'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: not all arguments converted during string formatting
```

Related to: #411 pypa/twine#552 python-poetry/poetry#1719

The above issues resolved the exception root causes but never fixed the second exception thrown from the exception handling block.
