### PR TITLE
without backends, always use fail backend, not empty chainer

### DIFF
--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -21,9 +21,11 @@ class ChainerBackend(backend.KeyringBackend):
     @classmethod
     def priority(cls):
         """
-        High-priority if there are backends to chain, otherwise 0.
+        If there are backends to chain, high priority
+        Otherwise very low priority since our operation when empty
+        is the same as null.
         """
-        return 10 * (len(cls.backends) > 1)
+        return 10 if len(cls.backends) > 1 else -10
 
     @properties.ClassProperty
     @classmethod

--- a/keyring/backends/fail.py
+++ b/keyring/backends/fail.py
@@ -1,4 +1,5 @@
 from ..backend import KeyringBackend
+from ..errors import NoKeyringError
 
 
 class Keyring(KeyringBackend):
@@ -9,7 +10,7 @@ class Keyring(KeyringBackend):
     >>> kr.get_password('svc', 'user')
     Traceback (most recent call last):
     ...
-    RuntimeError: ...No recommended backend...
+    keyring.errors.NoKeyringError: ...No recommended backend...
     """
 
     priority = 0
@@ -21,6 +22,6 @@ class Keyring(KeyringBackend):
             "you want to use the non-recommended backends. See "
             "https://pypi.org/project/keyring for details."
         )
-        raise RuntimeError(msg)
+        raise NoKeyringError(msg)
 
     set_password = delete_password = get_password

--- a/keyring/errors.py
+++ b/keyring/errors.py
@@ -29,6 +29,11 @@ class KeyringLocked(KeyringError):
     """
 
 
+class NoKeyringError(KeyringError, RuntimeError):
+    """Raised when there is no keyring backend
+    """
+
+
 class ExceptionRaisedContext:
     """
     An exception-trapping context that indicates whether an exception was

--- a/keyring/errors.py
+++ b/keyring/errors.py
@@ -25,7 +25,7 @@ class InitError(KeyringError):
 
 
 class KeyringLocked(KeyringError):
-    """Raised when the keyring could not be initialised
+    """Raised when the keyring failed unlocking
     """
 
 


### PR DESCRIPTION
This lowers chainer's priority down to -10 if it has no backends, since it shouldn't be used - its behavior when empty is the same as the null backend.

This also introduces a new NoKeyringError class, which inherits from both KeyringError as well as RuntimeError, so it can be used in the fail backend, and keep backwards compatibility (as the fail backend previously raised RuntimeError).  The new error class allows callers to detect and handle if there are no backends, without having to catch the ambiguous RuntimeError.