### PR TITLE
Use correct XDG default for XDG_CONFIG_HOME

### DIFF
--- a/keyring/util/platform_.py
+++ b/keyring/util/platform_.py
@@ -56,7 +56,7 @@ def _config_root_Linux():
     location.
     """
     _check_old_config_root()
-    fallback = os.path.expanduser('~/.local/share')
+    fallback = os.path.expanduser('~/.config')
     key = 'XDG_CONFIG_HOME'
     root = os.environ.get(key, None) or fallback
     return os.path.join(root, 'python_keyring')


### PR DESCRIPTION
The default for when `XDG_CONFIG_HOME` is not defined should be
`~/.config` and not `~/.local/share`. This creates another backwards
compatibility break, but one that _check_old_config_root already
handles.