### PR TITLE
feat: support discovering a credential's username on KWallet too

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v21.4.0
+-------
+
+* #431: KWallet backend now supports ``get_credential``.
+
 v21.3.1
 -------
 


### PR DESCRIPTION
Implement the get_credential method for the KWallet backend. This now
allows lookup of a credential by 'service' name only, not requiring the
'username'.

Implements #431