### PR TITLE
Remove duplicate license trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ url = https://github.com/jaraco/keyring
 classifiers =
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers
-	License :: OSI Approved :: MIT License
 	License :: OSI Approved :: Python Software Foundation License
 	License :: OSI Approved :: MIT License
 	Programming Language :: Python :: 3


### PR DESCRIPTION
I discovered the duplicate when I checked the license of this software with the `pip show` command.

```bash
$ pip show -v keyring
Name: keyring
Version: 21.3.1
# snip
Classifiers:
  Development Status :: 5 - Production/Stable
  Intended Audience :: Developers
  License :: OSI Approved :: MIT License
  License :: OSI Approved :: Python Software Foundation License
  License :: OSI Approved :: MIT License
  Programming Language :: Python :: 3
  Programming Language :: Python :: 3 :: Only
```

It looks like a triple license.

This is a very small problem, in my opinion. Hopefully this will be resolved in the next release version.