### PR TITLE
Fix KWallet.get_credential() regression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v21.4.1
+-------
+
+* #463: Fixed regression in KWallet ``get_credential``
+  where a simple string was returned instead of a
+  SimpleCredential.
+
 v21.4.0
 -------
 

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -135,8 +135,6 @@ class DBusKeyring(KeyringBackend):
             )
             return SimpleCredential(str(username), str(password))
 
-        return None
-
     def set_password(self, service, username, password):
         """Set password for the username of the service"""
         if not self.connected(service):

--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -123,7 +123,8 @@ class DBusKeyring(KeyringBackend):
         Otherwise, it will return the first username and password combo that it finds.
         """
         if username is not None:
-            return self.get_password(service, username)
+            return super().get_credential(service, username)
+
         if not self.connected(service):
             # the user pressed "cancel" when prompted to unlock their keyring.
             raise KeyringLocked("Failed to unlock the keyring!")
@@ -133,6 +134,8 @@ class DBusKeyring(KeyringBackend):
                 self.handle, service, username, self.appid
             )
             return SimpleCredential(str(username), str(password))
+
+        return None
 
     def set_password(self, service, username, password):
         """Set password for the username of the service"""


### PR DESCRIPTION
#459 introduced a regression.

Docs:
> get_credential(service, username): Return a credential object stored in
> the active keyring. This object contains at least username and password
> attributes for the specified service, where the returned username may be
> different from the argument.

Prior to this commit, `get_credential()` returned the password as a string, without wrapping the credential into a `SimpleCredential` object.