### PR TITLE
Disable SecretService and KWallet backends if the corresponding names are not available on D-Bus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+v21.5.0
+-------
+
+* #474: SecretService and KWallet backends are now
+  disabled if the relevant names are not available on
+  D-Bus. Keyring should now be much more responsive
+  in these environments.
+
 v21.4.1
 -------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
 	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
-	SecretStorage>=3; sys_platform=="linux"
+	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
 	importlib_metadata >= 1; python_version < "3.8"
 setup_requires = setuptools_scm[toml] >= 3.4.1


### PR DESCRIPTION
First, check if the name is already taken by some application. If no, check if the service can be activated dynamically.

@takluyver Please review this if you have time. And thanks again for your suggestion!

This fixes #162, #434, #473.