### PR TITLE
Initialise backend on first use instead of on import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+v21.6.0
+-------
+
+* #403: Keyring no longer eagerly initializes the backend
+  on import, but instead defers the backend initialization
+  until a keyring is accessed. Any callers reliant on this
+  early intialization behavior may need to call
+  ``keyring.core.init_backend()`` to explicitly initialize
+  the detected backend.
+
 v21.5.0
 -------
 

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -28,6 +28,8 @@ def set_keyring(keyring):
 
 def get_keyring():
     """Get current keyring backend."""
+    if _keyring_backend is None:
+        init_backend()
     return _keyring_backend
 
 
@@ -50,22 +52,22 @@ def disable():
 
 def get_password(service_name, username):
     """Get password from the specified service."""
-    return _keyring_backend.get_password(service_name, username)
+    return get_keyring().get_password(service_name, username)
 
 
 def set_password(service_name, username, password):
     """Set password for the user in the specified service."""
-    _keyring_backend.set_password(service_name, username, password)
+    get_keyring().set_password(service_name, username, password)
 
 
 def delete_password(service_name, username):
     """Delete the password for the user in the specified service."""
-    _keyring_backend.delete_password(service_name, username)
+    get_keyring().delete_password(service_name, username)
 
 
 def get_credential(service_name, username):
     """Get a Credential for the specified service."""
-    return _keyring_backend.get_credential(service_name, username)
+    return get_keyring().get_credential(service_name, username)
 
 
 def recommended(backend):
@@ -187,7 +189,3 @@ def _load_keyring_path(config):
         sys.path.insert(0, path)
     except (configparser.NoOptionError, configparser.NoSectionError):
         pass
-
-
-# init the _keyring_backend
-init_backend()


### PR DESCRIPTION
This seems so simple I kind of think I must be missing something, but `tox` passes on my (Linux) system.

Doing complicated stuff on import is generally best avoided, because we typically assume that imports are fast and reliable. This simply defers selecting and initialising a backend to the first time any of the public API functions are called. The only possible negative impact I can think of is if the environment changes between import and first use, it may lead to using a different backend. But it's hard to come up with realistic cases where that would be a problem, and if it is, the caller can use `get_keyring()` to initialise the backend early.

Closes #403.