### PR TITLE
Add support for UTF-8 decoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+v21.3.0
+-------
+
+* #438: For better interoperability with other
+  applications, ``Windows`` backend now attempts to
+  decode passwords using UTF-8 if UTF-16 decoding fails.
+  Passwords are still stored as UTF-16.
+
 v21.2.1
 -------
 

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -158,9 +158,13 @@ class WinVaultKeyring(KeyringBackend):
             if not res:
                 return None
         try:
-            return SimpleCredential(res['UserName'], res['CredentialBlob'].decode('utf-16'))
+            return SimpleCredential(
+                res['UserName'], res['CredentialBlob'].decode('utf-16')
+            )
         except UnicodeDecodeError:
-            return SimpleCredential(res['UserName'], res['CredentialBlob'].decode('utf-8'))
+            return SimpleCredential(
+                res['UserName'], res['CredentialBlob'].decode('utf-8')
+            )
 
 
 class OldPywinError:

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -86,7 +86,10 @@ class WinVaultKeyring(KeyringBackend):
         if not res:
             return None
         blob = res['CredentialBlob']
-        return blob.decode('utf-16')
+        try:
+            return blob.decode("utf-16")
+        except UnicodeDecodeError:
+            return blob.decode("utf-8")
 
     def _get_password(self, target):
         try:
@@ -154,7 +157,10 @@ class WinVaultKeyring(KeyringBackend):
             res = self._get_password(service)
             if not res:
                 return None
-        return SimpleCredential(res['UserName'], res['CredentialBlob'].decode('utf-16'))
+        try:
+            return SimpleCredential(res['UserName'], res['CredentialBlob'].decode('utf-16'))
+        except UnicodeDecodeError:
+            return SimpleCredential(res['UserName'], res['CredentialBlob'].decode('utf-8'))
 
 
 class OldPywinError:

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 
 from ..util import properties
 from ..backend import KeyringBackend
@@ -22,6 +23,7 @@ with ExceptionRaisedContext() as missing_deps:
         # force demand import to raise ImportError
         win32cred.__name__
 
+log = logging.getLogger(__name__)
 
 __metaclass__ = type
 
@@ -53,7 +55,12 @@ class DecodingCredential(dict):
         try:
             return cred.decode('utf-16')
         except UnicodeDecodeError:
-            return cred.decode('utf-8')
+            decoded_cred_utf8 = cred.decode('utf-8')
+            log.warning(
+                "Retrieved an UTF-8 encoded credential. Please be aware that "
+                "this library only writes credentials in UTF-16."
+            )
+            return decoded_cred_utf8
 
 
 class WinVaultKeyring(KeyringBackend):

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -87,9 +87,9 @@ class WinVaultKeyring(KeyringBackend):
             return None
         blob = res['CredentialBlob']
         try:
-            return blob.decode("utf-16")
+            return blob.decode('utf-16')
         except UnicodeDecodeError:
-            return blob.decode("utf-8")
+            return blob.decode('utf-8')
 
     def _get_password(self, target):
         try:

--- a/tests/backends/test_Windows.py
+++ b/tests/backends/test_Windows.py
@@ -21,8 +21,45 @@ class TestWinVaultKeyring(BackendBasicTests):
     def init_keyring(self):
         return keyring.backends.Windows.WinVaultKeyring()
 
+    def set_utf8_password(self, service, username, password):
+        """
+        Write a UTF-8 encoded password using win32ctypes primitives
+        """
+        from win32ctypes.core import _authentication as auth
+        from win32ctypes.core.ctypes._common import LPBYTE
+        from ctypes import cast, c_char, create_string_buffer, sizeof
+
+        credential = dict(
+            Type=1,
+            TargetName=service,
+            UserName=username,
+            CredentialBlob=password,
+            Comment="Stored using python-keyring",
+            Persist=3,
+        )
+
+        c_cred = auth.CREDENTIAL.fromdict(credential, 0)
+        blob_data = create_string_buffer(password.encode("utf-8"))
+        c_cred.CredentialBlobSize = sizeof(blob_data) - sizeof(c_char)
+        c_cred.CredentialBlob = cast(blob_data, LPBYTE)
+        c_cred_pointer = auth.PCREDENTIAL(c_cred)
+        auth._CredWrite(c_cred_pointer, 0)
+
+        self.credentials_created.add((service, username))
+
     def test_long_password_nice_error(self):
         self.keyring.set_password('system', 'user', 'x' * 512 * 2)
+
+    def test_read_utf8_password(self):
+        """
+        Write a UTF-8 encoded credential and make sure it can be read back correctly.
+        """
+        service = "keyring-utf8-test"
+        username = "keyring"
+        password = "utf8-test"
+
+        self.set_utf8_password(service, username, password)
+        assert self.keyring.get_password(service, username) == password
 
 
 @pytest.mark.skipif('sys.platform != "win32"')

--- a/tests/backends/test_Windows.py
+++ b/tests/backends/test_Windows.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 import keyring.backends.Windows
-from keyring.testing.backend import BackendBasicTests
+from keyring.testing.backend import BackendBasicTests, UNICODE_CHARS
 
 
 @pytest.mark.skipif(
@@ -56,7 +56,7 @@ class TestWinVaultKeyring(BackendBasicTests):
         """
         service = "keyring-utf8-test"
         username = "keyring"
-        password = "utf8-test"
+        password = "utf8-test" + UNICODE_CHARS
 
         self.set_utf8_password(service, username, password)
         assert self.keyring.get_password(service, username) == password


### PR DESCRIPTION
This PR adds support for UTF-8 password decoding as discussed in https://github.com/jaraco/keyring/issues/438

Wondering if we should add a warning when UTF-16 decoding fails? Something like "you can read this password but won't be able to write it back in the same format using this library at this time"?

Thanks!