### PR TITLE
Fix windows user expansion

### DIFF
--- a/keyring/util/platform_.py
+++ b/keyring/util/platform_.py
@@ -56,9 +56,9 @@ def _config_root_Linux():
     location.
     """
     _check_old_config_root()
-    fallback = os.path.join(os.path.expanduser('~'), '.config')
     key = 'XDG_CONFIG_HOME'
-    root = os.environ.get(key, None) or fallback
+    home = os.path.expanduser('~')
+    root = os.environ.get(key, None) or os.path.join(home, '.config')
     return os.path.join(root, 'python_keyring')
 
 

--- a/keyring/util/platform_.py
+++ b/keyring/util/platform_.py
@@ -56,7 +56,7 @@ def _config_root_Linux():
     location.
     """
     _check_old_config_root()
-    fallback = os.path.expanduser('~/.config')
+    fallback = os.path.join(os.path.expanduser('~'), '.config')
     key = 'XDG_CONFIG_HOME'
     root = os.environ.get(key, None) or fallback
     return os.path.join(root, 'python_keyring')


### PR DESCRIPTION
Thus retrieves the separator from `os.sep`.

```
>>> os.path.expanduser('~/.config')
c:\Users\username/.config

>>> os.path.join(os.path.expanduser('~'), '.config')
c:\Users\username\.config
```