### PR TITLE
Ensure that 'set_properties_from_env' is part of every keyring's initialization.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v23.0.0
+-------
+
+* Backends now all invoke ``set_properties_from_env`` on
+  self in the initializer. Derived backends should be sure
+  to invoke ``super().__init__()``.
+
 v22.4.0
 -------
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -41,6 +41,9 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
     this interface.
     """
 
+    def __init__(self):
+        self.set_properties_from_env()
+
     # @abc.abstractproperty
     def priority(cls):
         """

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -24,7 +24,6 @@ def set_keyring(keyring):
     if not isinstance(keyring, backend.KeyringBackend):
         raise TypeError("The keyring must be a subclass of KeyringBackend")
     _keyring_backend = keyring
-    keyring.set_properties_from_env()
 
 
 def get_keyring() -> backend.KeyringBackend:


### PR DESCRIPTION
Fixes #495.