### PR TITLE
Use stdlib `importlib.metadata` on Python 3.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v23.0.1
+-------
+
+* #499: Use the standard library ``importlib.metadata`` package
+  on Python 3.8 and later, and the ``importlib_metadata`` backport
+  only on earlier versions.
+
 v23.0.0
 -------
 

--- a/hook-keyring.backend.py
+++ b/hook-keyring.backend.py
@@ -1,6 +1,9 @@
 # Used by pyinstaller to expose hidden imports
 
-import importlib_metadata as metadata
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 
 
 hiddenimports = [ep.value for ep in metadata.entry_points(group='keyring.backends')]

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -9,7 +9,10 @@ import operator
 
 from typing import Optional
 
-import importlib_metadata as metadata
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 
 from . import credentials, errors, util
 from .util import properties

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
 	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
-	importlib_metadata >= 3.6
+	importlib_metadata >= 3.6; python_version<"3.8"
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,7 @@
-import importlib_metadata as metadata
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 
 from keyring import backend
 


### PR DESCRIPTION
Fixes #499.