### PR TITLE
Prefer stdlib importlib.metdata

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -9,7 +9,13 @@ import operator
 
 from typing import Optional
 
-import importlib_metadata as metadata
+try:
+    # python 3.8 and later
+    import importlib.metadata as metadata
+except ImportError:
+    # python 3.7 and earlier
+    import importlib_metadata as metadata
+
 
 from . import credentials, errors, util
 from .util import properties

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
 	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
-	importlib_metadata >= 3.6
+	importlib_metadata >= 3.6; python_version < "3.8"
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,9 @@
-import importlib_metadata as metadata
+try:
+    # python 3.8 and later
+    import importlib.metadata as metadata
+except ImportError:
+    # python 3.7 and earlier
+    import importlib_metadata as metadata
 
 from keyring import backend
 


### PR DESCRIPTION
Importlib_metadata is available as part of the standard library in python >= "3.8".

Noticed it was failing in https://github.com/NixOS/nixpkgs/pull/119819#discussion_r616810205