### PR TITLE
Make MacOS Error class inherit from KeyringError

### DIFF
--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -3,6 +3,7 @@ import ctypes
 import struct
 from ctypes import c_void_p, c_uint16, c_uint32, c_int32, c_char_p, POINTER
 
+from ...errors import KeyringError
 
 sec_keychain_ref = sec_keychain_item_ref = c_void_p
 OS_status = c_int32
@@ -30,7 +31,7 @@ SecKeychainCopyDefault.argtypes = (POINTER(sec_keychain_ref),)
 SecKeychainCopyDefault.restype = OS_status
 
 
-class Error(Exception):
+class Error(KeyringError):
     @classmethod
     def raise_for_status(cls, status):
         if status == 0:


### PR DESCRIPTION
This way it can be caught from outside without using MacOS-specific imports.

The `KeyringError` class specifies that it is the base class of keyring's errors. Well, it turned out it was not the base class of all of them. Keyring was still raising errors that were not subclasses of that `KeyringError` class. This change makes those a subclass of `KeyringError` too.

There is something to be said for that `KeyringDenied` would also have to be a subclass of `KeyringLocked`, and so on. However the descriptions of those errors don't match completely, and this would prevent them from being a subclass of the Error class (unless you want to get into the mess of multiple inheritance). So I think this would be a more safe approach.

With this change, if the user of the library wants to catch all errors related to the keyring, they just have to catch `KeyringError`. Without this change, they would have to make an import on the MacOS API details (which is giving errors for us as well when this is done on Windows, so OS-conditional imports need to be made). This would be difficult to discover for most developers as there is nothing about it in the documentation.