### PR TITLE
Use Session collection for testing libsecret backend

### DIFF
--- a/keyring/backends/libsecret.py
+++ b/keyring/backends/libsecret.py
@@ -40,6 +40,7 @@ class Keyring(KeyringBackend):
                 "username": Secret.SchemaAttributeType.STRING,
             },
         )
+        collection = Secret.COLLECTION_DEFAULT
 
     @properties.ClassProperty
     @classmethod
@@ -77,7 +78,6 @@ class Keyring(KeyringBackend):
 
     def set_password(self, service, username, password):
         """Set password for the username of the service"""
-        collection = getattr(self, 'preferred_collection', Secret.COLLECTION_DEFAULT)
         attributes = {
             "application": self.appid,
             "service": service,
@@ -86,7 +86,7 @@ class Keyring(KeyringBackend):
         label = "Password for '{}' on '{}'".format(username, service)
         try:
             stored = Secret.password_store_sync(
-                self.schema, attributes, collection, label, password, None
+                self.schema, attributes, self.collection, label, password, None
             )
         except GLib.Error as error:
             quark = GLib.quark_try_string('secret-error')

--- a/keyring/backends/libsecret.py
+++ b/keyring/backends/libsecret.py
@@ -77,7 +77,7 @@ class Keyring(KeyringBackend):
 
     def set_password(self, service, username, password):
         """Set password for the username of the service"""
-        collection = Secret.COLLECTION_DEFAULT
+        collection = getattr(self, 'preferred_collection', Secret.COLLECTION_DEFAULT)
         attributes = {
             "application": self.appid,
             "service": service,

--- a/tests/backends/test_libsecret.py
+++ b/tests/backends/test_libsecret.py
@@ -18,6 +18,7 @@ class TestLibSecretKeyring(BackendBasicTests):
             "password prompts are for this keyring"
         )
         keyring = libsecret.Keyring()
+        keyring.preferred_collection = 'session'
         return keyring
 
 

--- a/tests/backends/test_libsecret.py
+++ b/tests/backends/test_libsecret.py
@@ -18,7 +18,7 @@ class TestLibSecretKeyring(BackendBasicTests):
             "password prompts are for this keyring"
         )
         keyring = libsecret.Keyring()
-        keyring.preferred_collection = 'session'
+        keyring.collection = 'session'
         return keyring
 
 


### PR DESCRIPTION
This is something I needed to apply to make the tests pass for Debian package.

The Session collection is not documented in the specification and is specific to GNOME Keyring, but we do the same for testing SecretStorage backend:

https://github.com/jaraco/keyring/blob/fb37652fabb6fafd52603bf970eeacf54c9e515e/tests/backends/test_SecretService.py#L21

The login collection is not available in a clean environment, which results in this error:

    No such interface “org.freedesktop.Secret.Collection” on object at path /org/freedesktop/secrets/collection/login