### PR TITLE
add version to __init__.py to know when to use specific backends.

### DIFF
--- a/keyring/__init__.py
+++ b/keyring/__init__.py
@@ -7,6 +7,8 @@ from .core import (
     get_credential,
 )
 
+__version__ = "23.2.1"
+
 __all__ = (
     'set_keyring',
     'get_keyring',


### PR DESCRIPTION
Added the product version number in order to know when to use what backends.  This will help addresses the issues like this when backends are deprecated: https://github.com/jaraco/keyring/issues/504 . 