### PR TITLE
Change get_credential to return generic Credential

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v23.2.2
+-------
+
+* #542: Change get_credential to return generic Credential.
+
 v23.2.1
 -------
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -125,7 +125,7 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
         self,
         service: str,
         username: Optional[str],
-    ) -> Optional[credentials.SimpleCredential]:
+    ) -> Optional[credentials.Credential]:
         """Gets the username and password for the service.
         Returns a Credential instance.
 


### PR DESCRIPTION
A keyring backend may want to return SimpleCredential or EnvironCredential