### PR TITLE
Add equality operator to EnvironCredential

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v23.4.0
+-------
+
+* #549: EnvironCredential now allows for equality
+  comparison.
+
 v23.3.0
 -------
 

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -39,6 +39,15 @@ class EnvironCredential(Credential):
         self.user_env_var = user_env_var
         self.pwd_env_var = pwd_env_var
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, EnvironCredential):
+            return NotImplemented
+
+        return (
+            self.user_env_var == other.user_env_var
+            and self.pwd_env_var == other.pwd_env_var
+        )
+
     def _get_env(self, env_var):
         """Helper to read an environment variable"""
         value = os.environ.get(env_var)

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -31,8 +31,20 @@ class SimpleCredential(Credential):
 
 
 class EnvironCredential(Credential):
-    """Source credentials from environment variables.
+    """
+    Source credentials from environment variables.
+
     Actual sourcing is deferred until requested.
+
+    Supports comparison by equality.
+
+    >>> e1 = EnvironCredential('a', 'b')
+    >>> e2 = EnvironCredential('a', 'b')
+    >>> e3 = EnvironCredential('a', 'c')
+    >>> e1 == e2
+    True
+    >>> e2 == e3
+    False
     """
 
     def __init__(self, user_env_var, pwd_env_var):

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -40,13 +40,7 @@ class EnvironCredential(Credential):
         self.pwd_env_var = pwd_env_var
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, EnvironCredential):
-            return NotImplemented
-
-        return (
-            self.user_env_var == other.user_env_var
-            and self.pwd_env_var == other.pwd_env_var
-        )
+        return vars(self) == vars(other)
 
     def _get_env(self, env_var):
         """Helper to read an environment variable"""


### PR DESCRIPTION
It would be useful for using EnvironCredential in unit tests if it has the equality operator implemented.