### PR TITLE
"take-2": new Windows backend, ctypes-based, separate class which shards via Attributes

### DIFF
--- a/keyring/backends/Windows/api.py
+++ b/keyring/backends/Windows/api.py
@@ -1,0 +1,273 @@
+from ctypes import (
+    POINTER,
+    Structure,
+    WinError,
+    byref,
+    c_char_p,
+    c_uint32,
+    c_wchar_p,
+    cast,
+    pointer,
+    string_at,
+    windll,
+)
+from ctypes.wintypes import BOOL, DWORD, LPBYTE, LPVOID
+
+ATTRIBUTE_KEYWORD = 'python-keyring:authstate'
+
+
+# region ctypes wrapper structures
+
+
+class FILETIME(Structure):
+    _fields_ = [
+        ('dwLowDateTime', c_uint32),
+        ('dwHighDateTime', c_uint32),
+    ]
+
+    def asdict(self):
+        return {field: getattr(self, field) for field, _ in self._fields_}
+
+
+class CREDENTIAL_ATTRIBUTEW(Structure):
+    _fields_ = [
+        ('Keyword', c_wchar_p),
+        ('Flags', DWORD),
+        ('ValueSize', DWORD),
+        ('Value', LPBYTE),
+    ]
+
+    def asdict(self):
+        result = {}
+
+        for field, _ in self._fields_:
+            value = getattr(self, field)
+
+            if field != 'Value':
+                result[field] = value
+            else:
+                result[field] = string_at(value, getattr(self, 'ValueSize'))
+
+        return result
+
+
+class CREDENTIALW(Structure):
+    _fields_ = [
+        ('Flags', DWORD),
+        ('Type', DWORD),
+        ('TargetName', c_wchar_p),
+        ('Comment', c_wchar_p),
+        ('LastWritten', FILETIME),
+        ('CredentialBlobSize', DWORD),
+        ('CredentialBlob', LPBYTE),
+        ('Persist', DWORD),
+        ('AttributeCount', DWORD),
+        ('Attributes', POINTER(CREDENTIAL_ATTRIBUTEW)),
+        ('TargetAlias', c_wchar_p),
+        ('UserName', c_wchar_p),
+    ]
+
+    def asdict(self):
+        result = {}
+
+        for field, _ in self._fields_:
+            value = getattr(self, field)
+
+            if field == 'LastWritten':
+                result[field] = value.asdict()
+            elif field == 'Attributes':
+                attr_dict = {}
+                for i in range(result['AttributeCount']):
+                    if value[i]:  # NULL pointer is treated as False by ctypes
+                        attr = value[i].asdict()
+                        attr_dict[attr['Keyword']] = attr
+                result[field] = attr_dict
+            elif field == 'CredentialBlob':
+                blob = string_at(value, getattr(self, 'CredentialBlobSize'))
+                result[field] = blob
+            else:
+                result[field] = value
+
+        return result
+
+
+# endregion
+
+
+# region Win32 API declarations
+
+
+def errcheck(result, func, args):
+    if not result:
+        raise WinError()
+
+
+_CredReadW = windll.advapi32.CredReadW
+_CredReadW.argtypes = [c_wchar_p, DWORD, DWORD, POINTER(POINTER(CREDENTIALW))]
+_CredReadW.restype = BOOL
+_CredReadW.errcheck = errcheck  # type: ignore
+
+_CredWriteW = windll.advapi32.CredWriteW
+_CredWriteW.argtypes = [POINTER(CREDENTIALW), DWORD]
+_CredWriteW.restype = BOOL
+_CredWriteW.errcheck = errcheck  # type: ignore
+
+_CredDeleteW = windll.advapi32.CredDeleteW
+_CredDeleteW.argtypes = [c_wchar_p, DWORD, DWORD]
+_CredDeleteW.restype = BOOL
+_CredDeleteW.errcheck = errcheck  # type: ignore
+
+_CredEnumerateW = windll.advapi32.CredEnumerateW
+_CredEnumerateW.argtypes = [
+    c_wchar_p,
+    DWORD,
+    POINTER(DWORD),
+    POINTER(POINTER(POINTER(CREDENTIALW))),
+]
+_CredEnumerateW.restype = BOOL
+_CredEnumerateW.errcheck = errcheck  # type: ignore
+
+_CredFree = windll.advapi32.CredFree
+_CredFree.argtypes = [LPVOID]
+_CredFree.restype = None
+
+CRED_TYPE_GENERIC = 1
+CRED_PERSIST_SESSION = 1
+CRED_PERSIST_LOCAL_MACHINE = 2
+CRED_PERSIST_ENTERPRISE = 3
+CRED_ENUMERATE_ALL_CREDENTIALS = 1
+CRED_MAX_VALUE_SIZE = 256
+CRED_MAX_ATTRIBUTES = 64
+MAX_PASSWORD_BYTES = CRED_MAX_VALUE_SIZE * CRED_MAX_ATTRIBUTES
+
+
+# endregion
+
+# region API
+
+
+def CredRead(Type, TargetName):
+    pcred = pointer(CREDENTIALW())
+    _CredReadW(TargetName, Type, 0, byref(pcred))
+    credential = pcred.contents.asdict()
+    _CredFree(pcred)
+    return credential
+
+
+def CredReadFromAttributes(Type, TargetName, Credential=None, encoding='utf-8'):
+    if Credential is None:
+        Credential = CredRead(Type, TargetName)
+
+    num_attrs = Credential['AttributeCount']
+    if num_attrs > 0:
+        attrs = Credential['Attributes']
+        accum = b''
+        for i, (key, attr) in enumerate(attrs.items()):
+            expected_key = '{}:{}'.format(ATTRIBUTE_KEYWORD, str(i))
+            if key == expected_key:
+                accum += string_at(attr['Value'], attr['ValueSize'])
+            else:
+                break
+
+        Credential['CredentialBlob'] = accum.decode(encoding)
+        Credential['CredentialBlobSize'] = len(Credential['CredentialBlob'])
+
+    return Credential
+
+
+def _create_attribute(keyword, value):
+    return CREDENTIAL_ATTRIBUTEW(
+        Keyword=keyword,
+        Flags=0,
+        ValueSize=len(value),
+        Value=cast(c_char_p(value), LPBYTE),
+    )
+
+
+def _password_to_attributes(cred_args, encoding):
+    password = cred_args['CredentialBlob']
+    pwd_len = len(password)
+    encoded_password = password.encode(encoding)
+    cred_args['CredentialBlob'] = None
+    cred_args['CredentialBlobSize'] = 0
+
+    n = CRED_MAX_VALUE_SIZE
+    max_shards = max((pwd_len + n - 1) // n, 1)
+
+    if max_shards > CRED_MAX_ATTRIBUTES:
+        raise ValueError(
+            MAX_PASSWORD_BYTES,
+            'password length {} is greater than max allowed ({})'.format(
+                pwd_len, MAX_PASSWORD_BYTES
+            ),
+        )
+
+    cred_attrs = (CREDENTIAL_ATTRIBUTEW * max_shards)()
+
+    for i in range(0, max_shards):
+        keyword = '{}:{}'.format(ATTRIBUTE_KEYWORD, str(i))
+        shard = encoded_password[i * n : (i + 1) * n]
+        cred_attrs[i] = _create_attribute(keyword, shard)
+
+    cred_args['AttributeCount'] = max_shards
+    cred_args['Attributes'] = cred_attrs
+
+
+# NOTE utf-16-le encodes without BOM, as does pywin32 and pywin32-ctypes
+def CredWrite(credential, Flags, encoding='utf-16-le'):
+    cred_args = {}
+    cred_args.update(credential)
+
+    cred_args['Flags'] = Flags
+
+    if 'TargetAlias' not in cred_args:
+        cred_args['TargetAlias'] = None
+
+    if 'AttributeCount' not in cred_args:
+        cred_args['AttributeCount'] = 0
+    if 'Attributes' not in cred_args:
+        cred_args['Attributes'] = None
+
+    password = cred_args['CredentialBlob']
+    encoded_password = password.encode(encoding)
+    cred_args['CredentialBlob'] = cast(encoded_password, LPBYTE)
+    cred_args['CredentialBlobSize'] = len(encoded_password)
+
+    cred = CREDENTIALW(**cred_args)
+    _CredWriteW(byref(cred), Flags)
+
+
+def CredWriteToAttributes(credential, Flags, encoding='utf-8'):
+    cred_args = {}
+    cred_args.update(credential)
+
+    cred_args['Flags'] = Flags
+
+    if 'TargetAlias' not in cred_args:
+        cred_args['TargetAlias'] = None
+
+    # Sets CredentialBlob, CredentialBlobSize, AttributeCount, Attributes
+    _password_to_attributes(cred_args, encoding)
+
+    cred = CREDENTIALW(**cred_args)
+    _CredWriteW(byref(cred), Flags)
+
+
+def CredDelete(Type, TargetName):
+    _CredDeleteW(TargetName, Type, 0)
+
+
+def CredEnumerate(Filter=None, Flags=CRED_ENUMERATE_ALL_CREDENTIALS):
+    pcount = pointer(DWORD())
+    ppcred = POINTER(POINTER(CREDENTIALW))()
+
+    _CredEnumerateW(Filter, Flags, pcount, byref(ppcred))
+
+    entries = []
+    for i in range(pcount.contents.value):
+        entries.append(ppcred[i].contents.asdict())
+
+    return entries
+
+
+# endregion

--- a/keyring/testing/backend.py
+++ b/keyring/testing/backend.py
@@ -163,3 +163,7 @@ class BackendBasicTests:
         monkeypatch.setattr(os, 'environ', env)
         self.keyring.set_properties_from_env()
         assert self.keyring.foo_bar == 'fizz buzz'
+
+    def test_delete_non_existent(self):
+        with pytest.raises(errors.PasswordDeleteError):
+            self.keyring.delete_password('not_a_thing', 'no-one')

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ packages = find_namespace:
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
 	importlib_metadata >= 3.6

--- a/tests/backends/test_Windows.py
+++ b/tests/backends/test_Windows.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 import keyring.backends.Windows
@@ -10,47 +8,10 @@ from keyring.testing.backend import BackendBasicTests, UNICODE_CHARS
     not keyring.backends.Windows.WinVaultKeyring.viable, reason="Needs Windows"
 )
 class TestWinVaultKeyring(BackendBasicTests):
-    def tearDown(self):
-        # clean up any credentials created
-        for cred in self.credentials_created:
-            try:
-                self.keyring.delete_password(*cred)
-            except Exception as e:
-                print(e, file=sys.stderr)
-
     def init_keyring(self):
         return keyring.backends.Windows.WinVaultKeyring()
 
-    def set_utf8_password(self, service, username, password):
-        """
-        Write a UTF-8 encoded password using win32ctypes primitives
-        """
-        from win32ctypes.core import _authentication as auth
-        from win32ctypes.core.ctypes._common import LPBYTE
-        from ctypes import cast, c_char, create_string_buffer, sizeof
-
-        credential = dict(
-            Type=1,
-            TargetName=service,
-            UserName=username,
-            CredentialBlob=password,
-            Comment="Stored using python-keyring",
-            Persist=3,
-        )
-
-        c_cred = auth.CREDENTIAL.fromdict(credential, 0)
-        blob_data = create_string_buffer(password.encode("utf-8"))
-        c_cred.CredentialBlobSize = sizeof(blob_data) - sizeof(c_char)
-        c_cred.CredentialBlob = cast(blob_data, LPBYTE)
-        c_cred_pointer = auth.PCREDENTIAL(c_cred)
-        auth._CredWrite(c_cred_pointer, 0)
-
-        self.credentials_created.add((service, username))
-
-    def test_long_password_nice_error(self):
-        self.keyring.set_password('system', 'user', 'x' * 512 * 2)
-
-    def test_read_utf8_password(self):
+    def test_read_odd_length_utf8_password(self):
         """
         Write a UTF-8 encoded credential and make sure it can be read back correctly.
         """
@@ -58,8 +19,85 @@ class TestWinVaultKeyring(BackendBasicTests):
         username = "keyring"
         password = "utf8-test" + UNICODE_CHARS
 
-        self.set_utf8_password(service, username, password)
+        self.keyring.set_password(service, username, password, encoding='utf-8')
         assert self.keyring.get_password(service, username) == password
+        self.credentials_created.add((service, username))
+
+    def test_read_even_length_utf8_password(self):
+        """
+        Write a UTF-8 encoded credential and make sure it can be read back correctly.
+        """
+        service = "keyring-utf8-test"
+        username = "keyring"
+        password = "utf8-test-" + UNICODE_CHARS
+
+        self.keyring.set_password(service, username, password, encoding='utf-8')
+
+        # TODO https://github.com/jaraco/keyring/issues/554
+        # The following line should be `==`, not `!=`.
+        assert self.keyring.get_password(service, username) != password
+        self.credentials_created.add((service, username))
+
+    def test_long_password_no_error(self):
+        service = 'system'
+        username = 'user'
+        self.keyring.set_password(service, username, 'x' * 1280)
+        assert self.keyring.get_password(service, username) == 'x' * 1280
+        self.credentials_created.add((service, username))
+
+    # NOTE maximum 64 attributes of 256 bytes each == max sharded encoded password
+    def test_too_long_password_test_error(self):
+        with pytest.raises(OSError) as e_info:
+            service = 'system'
+            username = 'user'
+            self.keyring.set_password(service, username, 'x' * 1281)
+            assert self.keyring.get_password(service, username) == 'x' * 1281
+
+        assert e_info.value.winerror == 1783
+
+    def test_enumerate(self):
+        from keyring.backends.Windows import api as win32cred
+
+        entries = win32cred.CredEnumerate()
+        assert entries
+
+    def test_set_persist(self):
+        keyring = self.keyring
+        keyring.persist = 'Enterprise'
+
+
+class TestWinVaultAttributesKeyring(TestWinVaultKeyring):
+    def init_keyring(self):
+        return keyring.backends.Windows.WinVaultAttributesKeyring()
+
+    def test_long_password_no_error(self):
+        service = 'system'
+        username = 'user'
+        self.keyring.set_password(service, username, 'x' * (64 * 256))
+        assert self.keyring.get_password(service, username) == 'x' * (64 * 256)
+        self.credentials_created.add((service, username))
+
+    # NOTE maximum 64 attributes of 256 bytes each == max sharded encoded password
+    def test_too_long_password_test_error(self):
+        with pytest.raises(ValueError) as e_info:
+            service = 'system'
+            username = 'user'
+            self.keyring.set_password(service, username, 'x' * (64 * 256 + 1))
+            assert self.keyring.get_password(service, username) == 'x' * (64 * 256 + 1)
+
+        assert e_info.value.args[0] == 64 * 256
+
+    def test_read_from_attributes(self):
+        from keyring.backends.Windows import api as win32cred
+
+        service = 'system'
+        username = 'user'
+        self.keyring.set_password(service, username, 'x' * (64 * 256))
+        cred = win32cred.CredReadFromAttributes(
+            Type=win32cred.CRED_TYPE_GENERIC, TargetName=service
+        )
+        assert cred['CredentialBlob'] == 'x' * (64 * 256)
+        self.credentials_created.add((service, username))
 
 
 @pytest.mark.skipif('sys.platform != "win32"')
@@ -68,3 +106,11 @@ def test_winvault_always_viable():
     The WinVault backend should always be viable on Windows.
     """
     assert keyring.backends.Windows.WinVaultKeyring.viable
+
+
+@pytest.mark.skipif('sys.platform != "win32"')
+def test_winvaultattributes_always_viable():
+    """
+    The WinVault backend should always be viable on Windows.
+    """
+    assert keyring.backends.Windows.WinVaultAttributesKeyring.viable


### PR DESCRIPTION
@jaraco, here's my fresh effort to implement an improved Windows backend, to the plan you outlined:

1. Determine if pywin32-ctypes can support the necessary interfaces herein and at least capture any shortcomings.
2. Port the existing backend to an API that supports the necessary interfaces (perhaps an updated version of pywin32-ctypes or maybe a bespoke implementation). Cut a release to get early feedback on any regressions related to that change.
3. Implement the ShardedKeyring as a specialized subclass or mix-in, encapsulating the sharding logic in one class. 

Re 1, I contacted [pywin32-ctypes](https://github.com/enthought/pywin32-ctypes/issues/105), and heard back that it would take a week or two to hear back from them.  I wrote the code that I would like to have from that project.  It is in `keyring/backends/Windows/api.py`.  I implemented it, this time, using only `ctypes`, and not `cffi`.

Re 2, I moved the existing `backends/Windows.py` to `backends/Windows/__init__.py`, and ported it to use `api.py`.  

Re 3, I implemented `class WinVaultAttributesKeyring(WinVaultKeyring)` to isolate the new sharding logic.

In order to study use-cases of `Credential Manager`, I implemented `CredEnumerate`, which let me more readily dump out all the credentials in my `Credential Manager`.  I learned that, apparently, Microsoft had the same issue we have, in needing more room for JWTs.  

Their sharding solution uses Attributes, rather than creating multiple entries.  I liked that much better, and so the sharding logic in this PR uses Attributes.  I'm including a redacted  version of that dump here, which includes the first few bytes of `CredentialBlob` from each entry.  I sure hope I redacted enough!!!
 
[redacted_credentials2.txt](https://github.com/jaraco/keyring/files/7656549/redacted_credentials2.txt)

While the introduction of the use of Attributes would be new to `keyring`, I restrict their use to the "_password won't fit and we raise  `1783` error_" case.  Passwords that fit are treated the same as in shipping `keyring`, so the risk introduced should be small.

I added a test illustrating the problem raised in https://github.com/jaraco/keyring/issues/554.  `def test_read_even_length_utf8_password(self)`

I also fixed the extra duplication of entries raised in https://github.com/jaraco/keyring/issues/545.  But I didn't know how to fix `get_credentials`, per [the observation you made](https://github.com/jaraco/keyring/issues/545#issuecomment-981121347).  

**What's left?:**
I don't understand the `priority` system 100%, and need some guidance there.  But I did add some tests explicitly targeting the new sharding backend.

I'd like to resolve the `get_credentials` part of the `compound_name` issue.  I don't understand the algorithm well enough to fix it myself.  In general, the idea that I call `set_password` with one `service`, and, later, the system renames it, yet transparently finds it for me, is pretty confusing to me.  I would benefit from more info about what problem is being solved.  Is it that the `keyring` model is that only the `(service, username)` is meant to be unique?  

My credentials file shows that only `keyring` users (and presumably other `pywin32` or `pywin32-ctypes` users) are using `UTF-16`.  Many of the credentials appear to be various 8-bit encodings, and typically do not appear to be Unicode encodings at all.  If my `Credential Manager` data is indicative, I don't think we are helping interoperability by imposing `UTF-16`.  Rather, I think we simply inherited this behavior from `pywin32`.  I'd love to discuss what we can do about this, without disrupting existing users.  