### PR TITLE
Add .coverage.* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
@@ -56,4 +57,3 @@ docs/_build/
 
 # PyBuilder
 target/
-


### PR DESCRIPTION
When I cloned this to do a little work on it, I noticed some coverage files popping up that could be in `.gitignore`.

<img width="417" alt="CleanShot 2022-02-13 at 13 43 03@2x" src="https://user-images.githubusercontent.com/649496/153771913-19933d10-6824-4b94-9cde-89d3448fac55.png">

