### PR TITLE
Test libsecret in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python:
         - 3.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,15 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        include:
+        - python: "os"
+          platform: ubuntu-latest
+          toxargs: "--sitepackages"
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
+        if: ${{ matrix.python != 'os' }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
@@ -25,7 +30,7 @@ jobs:
         run: |
           python -m pip install tox
       - name: Run tests
-        run: tox
+        run: tox ${{ matrix.toxargs }}
 
   release:
     needs: test


### PR DESCRIPTION
I don't have a fix yet for #561, but this change to the tests does surface it in CI. Previously it was skipped in every matrix because `import gi` usually doesn't work due tox / Python install / virtual environments.

I think the solution is to make `libsecret.Keyring.viable` be false in this kind of environment, but I haven't figured out a good way to do that yet (sounds like there are several other scenarios where libsecret should still work). Just wanted to push the failing test part in case anyone else is thinking about it!