### PR TITLE
Make `importlib_metadata` optional on Python 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
-	importlib_metadata >= 3.6
+	importlib_metadata >= 3.6; python_version<"3.10"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Hi, I think this will close #575.