### PR TITLE
Use native importlib.metadata when possible.

### DIFF
--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -2,6 +2,7 @@
 Keyring implementation support
 """
 
+import sys
 import os
 import abc
 import logging
@@ -9,7 +10,10 @@ import operator
 
 from typing import Optional
 
-import importlib_metadata as metadata
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    import importlib.metadata as metadata
 
 from . import credentials, errors, util
 from .util import properties

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
 	pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform=="win32"
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
-	importlib_metadata >= 3.6
+	importlib_metadata >= 3.6; python_version<'3.8'
 
 [options.packages.find]
 exclude =

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,9 @@
-import importlib_metadata as metadata
+import sys
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    import importlib.metadata as metadata
 
 from keyring import backend
 


### PR DESCRIPTION
The importlib_metadata backport is only needed for python 3.7 now, since python 3.6 is at End-of-Life, but keyring makes it, and its dependency zipp get downloaded and installed.