### PR TITLE
Add support for alternate keychains in expression.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@ v23.6.0
 -------
 
 * #575: Only require ``importlib_metadata`` on older Pythons.
+* #579: Add ``.with_keychain`` method on macOS for easy reference
+  to alternate keychains.
 
 v23.5.1
 -------

--- a/keyring/backends/macOS/__init__.py
+++ b/keyring/backends/macOS/__init__.py
@@ -66,3 +66,8 @@ class Keyring(KeyringBackend):
             raise PasswordDeleteError(
                 "Can't delete password in keychain: " "{}".format(e)
             )
+
+    def with_keychain(self, keychain):
+        alt = Keyring()
+        alt.keychain = keychain
+        return alt

--- a/tests/backends/test_macOS.py
+++ b/tests/backends/test_macOS.py
@@ -12,3 +12,9 @@ from keyring.backends import macOS
 class Test_macOSKeychain(BackendBasicTests):
     def init_keyring(self):
         return macOS.Keyring()
+
+    @pytest.mark.xfail
+    def test_alternate_keychain(self):
+        alt = self.keyring.with_keychain('abcd')
+        assert alt.keychain == 'abcd'
+        assert self.keyring.keychain is None

--- a/tests/backends/test_macOS.py
+++ b/tests/backends/test_macOS.py
@@ -13,8 +13,7 @@ class Test_macOSKeychain(BackendBasicTests):
     def init_keyring(self):
         return macOS.Keyring()
 
-    @pytest.mark.xfail
     def test_alternate_keychain(self):
         alt = self.keyring.with_keychain('abcd')
         assert alt.keychain == 'abcd'
-        assert self.keyring.keychain is None
+        assert self.keyring.keychain != 'abcd'


### PR DESCRIPTION
- Add test capturing need for an alternate keyring with an alternate keychain.
- Add support for getting another Keyring with an alternate keychain. Fixes #579.
- Update changelog.
