### PR TITLE
Let devpi fall back to other options if keyring fails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v23.7.0
+-------
+
+* #582: Suppress KeyringErrors for devpi client.
+
 v23.6.0
 -------
 

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,6 +1,7 @@
 from pluggy import HookimplMarker
 
 import keyring
+from keyring.errors import KeyringError
 
 
 hookimpl = HookimplMarker("devpiclient")
@@ -8,4 +9,7 @@ hookimpl = HookimplMarker("devpiclient")
 
 @hookimpl()
 def devpiclient_get_password(url, username):
-    return keyring.get_password(url, username)
+    try:
+        return keyring.get_password(url, username)
+    except KeyringError:
+        return None

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,5 +1,6 @@
+import contextlib
+
 from pluggy import HookimplMarker
-from jaraco.context import suppress
 
 import keyring
 from keyring.errors import KeyringError
@@ -9,6 +10,6 @@ hookimpl = HookimplMarker("devpiclient")
 
 
 @hookimpl()
-@suppress(KeyringError)
 def devpiclient_get_password(url, username):
-    return keyring.get_password(url, username)
+    with contextlib.suppress(KeyringError):
+        return keyring.get_password(url, username)

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,4 +1,5 @@
 from pluggy import HookimplMarker
+from jaraco.context import suppress
 
 import keyring
 from keyring.errors import KeyringError
@@ -8,8 +9,6 @@ hookimpl = HookimplMarker("devpiclient")
 
 
 @hookimpl()
+@suppress(KeyringError)
 def devpiclient_get_password(url, username):
-    try:
-        return keyring.get_password(url, username)
-    except KeyringError:
-        return None
+    return keyring.get_password(url, username)

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -9,7 +9,11 @@ from keyring.errors import KeyringError
 hookimpl = HookimplMarker("devpiclient")
 
 
+# https://github.com/jaraco/jaraco.context/blob/c3a9b739/jaraco/context.py#L205
+suppress = type('suppress', (contextlib.suppress, contextlib.ContextDecorator), {})
+
+
 @hookimpl()
+@suppress(KeyringError)
 def devpiclient_get_password(url, username):
-    with contextlib.suppress(KeyringError):
-        return keyring.get_password(url, username)
+    return keyring.get_password(url, username)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
 	importlib_metadata >= 3.6; python_version < "3.10"
+	jaraco.context
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
 	SecretStorage>=3.2; sys_platform=="linux"
 	jeepney>=0.4.2; sys_platform=="linux"
 	importlib_metadata >= 3.6; python_version < "3.10"
-	jaraco.context
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
keyring provides a plugin to supply the password to devpi-client. However, if keyring fails - e.g. it's installed but no backend is working, or unlocking the keyring fails - then `devpi login` becomes impossible, because the keyring exception is uncaught.

This catches any KeyringError, and returns None instead, which signals to devpi that it should try another way to get the password ([docs](https://devpi.net/docs/devpi/devpi/stable/+d/devguide/hooks.html#devpi-client-plugin-hooks-experimental)).