### PR TITLE
Allow scheme to be selectable in libsecret and SecretService backends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,21 @@
+v23.8.0
+-------
+
+* #448: ``SecretService`` and ``libsecret`` backends now support a
+  new ``SelectableScheme``, allowing the keys for "username" and
+  "service" to be overridden for compatibility with other schemes
+  such as KeypassXC.
+
+* Introduced a new ``.with_properties`` method on backends to
+  produce a new keyring with different properties. Use for example
+  to get a keyring with a different ``keychain`` (macOS) or
+  ``scheme`` (SecretService/libsecret). e.g.::
+
+    keypass = keyring.get_keyring().with_properties(scheme='KeypassXC')
+
+* ``.with_keychain`` method on macOS is superseded by ``.with_properties``
+  and so is now deprecated.
+
 v23.7.0
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,14 +4,14 @@ v23.8.0
 * #448: ``SecretService`` and ``libsecret`` backends now support a
   new ``SelectableScheme``, allowing the keys for "username" and
   "service" to be overridden for compatibility with other schemes
-  such as KeypassXC.
+  such as KeePassXC.
 
 * Introduced a new ``.with_properties`` method on backends to
   produce a new keyring with different properties. Use for example
   to get a keyring with a different ``keychain`` (macOS) or
   ``scheme`` (SecretService/libsecret). e.g.::
 
-    keypass = keyring.get_keyring().with_properties(scheme='KeypassXC')
+    keypass = keyring.get_keyring().with_properties(scheme='KeePassXC')
 
 * ``.with_keychain`` method on macOS is superseded by ``.with_properties``
   and so is now deprecated.

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -224,6 +224,17 @@ class SchemeSelectable:
     """
     Allow a backend to select different "schemes" for the
     username and service.
+
+    >>> backend = SchemeSelectable()
+    >>> backend._query('contoso', 'alice')
+    {'username': 'alice', 'service': 'contoso'}
+    >>> backend._query('contoso')
+    {'service': 'contoso'}
+    >>> backend.scheme = 'KeypassXC'
+    >>> backend._query('contoso', 'alice')
+    {'UserName': 'alice', 'Title': 'contoso'}
+    >>> backend._query('contoso', 'alice', foo='bar')
+    {'UserName': 'alice', 'Title': 'contoso', 'foo': 'bar'}
     """
 
     scheme = 'default'

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -218,3 +218,29 @@ def get_all_keyring():
     viable_classes = KeyringBackend.get_viable_backends()
     rings = util.suppress_exceptions(viable_classes, exceptions=TypeError)
     return list(rings)
+
+
+class SchemeSelectable:
+    """
+    Allow a backend to select different "schemes" for the
+    username and service.
+    """
+
+    scheme = 'default'
+    schemes = dict(
+        default=dict(username='username', service='service'),
+        KeypassXC=dict(username='UserName', service='Title'),
+    )
+
+    def _query(self, service, username):
+        scheme = self.schemes[self.scheme]
+        return (
+            {
+                scheme['username']: username,
+                scheme['service']: service,
+            }
+            if username
+            else {
+                scheme['service']: service,
+            }
+        )

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -232,9 +232,9 @@ class SchemeSelectable:
         KeypassXC=dict(username='UserName', service='Title'),
     )
 
-    def _query(self, service, username):
+    def _query(self, service, username=None, **base):
         scheme = self.schemes[self.scheme]
-        return (
+        return dict(
             {
                 scheme['username']: username,
                 scheme['service']: service,
@@ -242,5 +242,6 @@ class SchemeSelectable:
             if username
             else {
                 scheme['service']: service,
-            }
+            },
+            **base,
         )

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -6,6 +6,7 @@ import os
 import abc
 import logging
 import operator
+import copy
 
 from typing import Optional
 
@@ -150,6 +151,11 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
         props = filter(None, map(parse, os.environ.items()))
         for name, value in props:
             setattr(self, name, value)
+
+    def with_properties(self, **kwargs):
+        alt = copy.copy(self)
+        vars(alt).update(kwargs)
+        return alt
 
 
 class Crypter:

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -230,7 +230,7 @@ class SchemeSelectable:
     {'username': 'alice', 'service': 'contoso'}
     >>> backend._query('contoso')
     {'service': 'contoso'}
-    >>> backend.scheme = 'KeypassXC'
+    >>> backend.scheme = 'KeePassXC'
     >>> backend._query('contoso', 'alice')
     {'UserName': 'alice', 'Title': 'contoso'}
     >>> backend._query('contoso', 'alice', foo='bar')
@@ -240,7 +240,7 @@ class SchemeSelectable:
     scheme = 'default'
     schemes = dict(
         default=dict(username='username', service='service'),
-        KeypassXC=dict(username='UserName', service='Title'),
+        KeePassXC=dict(username='UserName', service='Title'),
     )
 
     def _query(self, service, username=None, **base):

--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 import logging
 
+from .. import backend
 from ..util import properties
 from ..backend import KeyringBackend
 from ..credentials import SimpleCredential
@@ -23,16 +24,10 @@ except AttributeError:
 log = logging.getLogger(__name__)
 
 
-class Keyring(KeyringBackend):
+class Keyring(backend.SchemeSelectable, KeyringBackend):
     """Secret Service Keyring"""
 
     appid = 'Python keyring library'
-    scheme = 'default'
-
-    schemes = dict(
-        default=dict(username='username', service='service'),
-        KeypassXC=dict(username='UserName', service='Title'),
-    )
 
     @properties.ClassProperty
     @classmethod
@@ -78,19 +73,6 @@ class Keyring(KeyringBackend):
             item.unlock()
         if item.is_locked():  # User dismissed the prompt
             raise KeyringLocked('Failed to unlock the item!')
-
-    def _query(self, service, username):
-        scheme = self.schemes[self.scheme]
-        return (
-            {
-                scheme['username']: username,
-                scheme['service']: service,
-            }
-            if username
-            else {
-                scheme['service']: service,
-            }
-        )
 
     def get_password(self, service, username):
         """Get password of the username for the service"""

--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -86,10 +86,7 @@ class Keyring(backend.SchemeSelectable, KeyringBackend):
     def set_password(self, service, username, password):
         """Set password for the username of the service"""
         collection = self.get_preferred_collection()
-        attributes = dict(
-            self._query(service, username),
-            application=self.appid,
-        )
+        attributes = self._query(service, username, application=self.appid)
         label = "Password for '{}' on '{}'".format(username, service)
         with closing(collection.connection):
             collection.create_item(label, attributes, password, replace=True)

--- a/keyring/backends/macOS/__init__.py
+++ b/keyring/backends/macOS/__init__.py
@@ -1,5 +1,6 @@
 import platform
 import os
+import warnings
 
 from ...backend import KeyringBackend
 from ...errors import PasswordSetError
@@ -68,4 +69,9 @@ class Keyring(KeyringBackend):
             )
 
     def with_keychain(self, keychain):
+        warnings.warn(
+            "macOS.Keyring.with_keychain is deprecated. Use with_properties instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.with_properties(keychain=keychain)

--- a/keyring/backends/macOS/__init__.py
+++ b/keyring/backends/macOS/__init__.py
@@ -68,6 +68,4 @@ class Keyring(KeyringBackend):
             )
 
     def with_keychain(self, keychain):
-        alt = Keyring()
-        alt.keychain = keychain
-        return alt
+        return self.with_properties(keychain=keychain)

--- a/keyring/testing/backend.py
+++ b/keyring/testing/backend.py
@@ -163,3 +163,10 @@ class BackendBasicTests:
         monkeypatch.setattr(os, 'environ', env)
         self.keyring.set_properties_from_env()
         assert self.keyring.foo_bar == 'fizz buzz'
+
+    def test_new_with_properties(self):
+        alt = self.keyring.with_properties(foo='bar')
+        assert alt is not self.keyring
+        assert alt.foo == 'bar'
+        with pytest.raises(AttributeError):
+            self.keyring.foo

--- a/tests/backends/test_macOS.py
+++ b/tests/backends/test_macOS.py
@@ -12,8 +12,3 @@ from keyring.backends import macOS
 class Test_macOSKeychain(BackendBasicTests):
     def init_keyring(self):
         return macOS.Keyring()
-
-    def test_alternate_keychain(self):
-        alt = self.keyring.with_keychain('abcd')
-        assert alt.keychain == 'abcd'
-        assert self.keyring.keychain != 'abcd'


### PR DESCRIPTION
- Add support for a scheme property in SecretService backend. Set to 'KeypassXC' to use the username/system convention from KeypassXC, either with KEYRING_PROPERTY_SCHEME or keyring.with_properties(scheme='KeypassXC'). Fixes #448.
- Add test for with_properties helper.
- Re-use with_properties in with_keychain.
- Deprecate macOS.Keyring.with_keychain, superseded by with_properties.
- Extract SchemeSelectable mixin
- Allow _query to include other keys
- Add SelectableScheme to libsecret.
- Add tests for SchemeSelectable.
