### PR TITLE
Fix regression which made libsecret backend unusable in v23.8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v23.8.1
+-------
+
+* #587: Fix regression in ``libsecret``.
+
 v23.8.0
 -------
 

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -250,7 +250,7 @@ class SchemeSelectable:
                 scheme['username']: username,
                 scheme['service']: service,
             }
-            if username
+            if username is not None
             else {
                 scheme['service']: service,
             },


### PR DESCRIPTION
libsecret/secret-schema.h has this enum:

```c
typedef enum {
    SECRET_SCHEMA_ATTRIBUTE_STRING = 0,
    SECRET_SCHEMA_ATTRIBUTE_INTEGER = 1,
    SECRET_SCHEMA_ATTRIBUTE_BOOLEAN = 2,
} SecretSchemaAttributeType;
```

Because of this, `bool(Secret.SchemaAttributeType.STRING)` evaluates to False. So when we do this, _query code ignores the second argument:

https://github.com/jaraco/keyring/blob/0ed196d309f657b69c0f9d76d7c9e5020b7e0b54/keyring/backends/libsecret.py#L40-L44

And it causes any use of libsecret backend to fail with this error:

    >>> import keyring.backends.libsecret
    >>> k = keyring.backends.libsecret.Keyring()
    >>> k.set_password('foo', 'bar', 'baz')

    (process:26311): libsecret-CRITICAL **: 19:22:53.299: secret_password_storev_sync: invalid username attribute for org.freedesktop.Secret.Generic schema
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/dmitry/upstream/keyring/keyring/backends/libsecret.py", line 98, in set_password
        raise PasswordSetError("Failed to store password!")
    keyring.errors.PasswordSetError: Failed to store password!