### PR TITLE
BF: allow for import of keyring.util.properties but with a Deprecation warning if used

### DIFF
--- a/keyring/util/__init__.py
+++ b/keyring/util/__init__.py
@@ -2,7 +2,7 @@ import functools
 
 # Compatibility layer to not break imports downstream
 # TODO: deprecate/remove fully later
-from .._compat import properties
+from .._compat import properties as _properties
 import warnings
 
 class _Properties_shim:
@@ -10,6 +10,8 @@ class _Properties_shim:
        warnings.warn(
            "properties from keyring.util are no longer supported, use keyring._compat",
            DeprecationWarning)
+       if not hasattr(_properties, a) and hasattr(_properties, a.lower()):
+           a = a.lower()
        return getattr(_properties, a)
 properties = _Properties_shim()
 

--- a/keyring/util/__init__.py
+++ b/keyring/util/__init__.py
@@ -1,5 +1,19 @@
 import functools
 
+# Compatibility layer to not break imports downstream
+# TODO: deprecate/remove fully later
+from .._compat import properties
+import warnings
+
+class _Properties_shim:
+    def __getattr__(self, a):
+       warnings.warn(
+           "properties from keyring.util are no longer supported, use keyring._compat",
+           DeprecationWarning)
+       return getattr(_properties, a)
+properties = _Properties_shim()
+
+
 
 def once(func):
     """


### PR DESCRIPTION
<details>
<summary>edit: no longer pertinent -- "shim" is complete and it seems that keyrings.alt tests run/pass (whatever is not skipped locally)</summary> 

Unfortunately it is not a complete solution to #593 since there was likely
also a breakage in API of those properties since it would lead to e.g.

	(git)lena:~/proj/misc/keyrings.alt[main]git
	$> python -c 'import keyrings.alt.file'
	Traceback (most recent call last):
	  File "<string>", line 1, in <module>
	  File "/home/yoh/proj/misc/keyrings.alt/keyrings/alt/file.py", line 67, in <module>
		class EncryptedKeyring(Encrypted, Keyring):
	  File "/home/yoh/proj/misc/keyrings.alt/keyrings/alt/file.py", line 73, in EncryptedKeyring
		@properties.ClassProperty
	  File "/home/yoh/proj/misc/keyring/keyring/util/__init__.py", line 12, in __getattr__
		return getattr(_properties, a)
	AttributeError: module 'keyring._properties_compat' has no attribute 'ClassProperty'. Did you mean: 'classproperty'?

so might need more compat shimming (allowing edits by maintainers for this PR, so push in if decide to take/improve it)

</details>

Closes #593