### PR TITLE
Apply workaround for decoratated function unrecognized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v23.9.3
+-------
+
+* #596: Add workaround for devpi_client hook with wrapped implementation.
+
 v23.9.2
 -------
 

--- a/conftest.py
+++ b/conftest.py
@@ -19,5 +19,3 @@ def macos_api_ignore():
 
 
 collect_ignore.extend(['keyring/backends/macOS/api.py'] * macos_api_ignore())
-
-collect_ignore.append('keyring/devpi_client.py')

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -13,7 +13,16 @@ hookimpl = pluggy.HookimplMarker("devpiclient")
 suppress = type('suppress', (contextlib.suppress, contextlib.ContextDecorator), {})
 
 
+def restore_signature(func):
+    # workaround for pytest-dev/pluggy#358
+    def wrapper(url, username):
+        return func(url, username)
+
+    return wrapper
+
+
 @hookimpl()
+@restore_signature
 @suppress(KeyringError)
 def devpiclient_get_password(url, username):
     """

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,12 +1,12 @@
 import contextlib
 
-from pluggy import HookimplMarker
+import pluggy
 
 import keyring
 from keyring.errors import KeyringError
 
 
-hookimpl = HookimplMarker("devpiclient")
+hookimpl = pluggy.HookimplMarker("devpiclient")
 
 
 # https://github.com/jaraco/jaraco.context/blob/c3a9b739/jaraco/context.py#L205
@@ -16,4 +16,8 @@ suppress = type('suppress', (contextlib.suppress, contextlib.ContextDecorator), 
 @hookimpl()
 @suppress(KeyringError)
 def devpiclient_get_password(url, username):
+    """
+    >>> pluggy._hooks.varnames(devpiclient_get_password)
+    (('url', 'username'), ())
+    """
     return keyring.get_password(url, username)

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -3,8 +3,7 @@ import functools
 
 import pluggy
 
-import keyring
-from keyring.errors import KeyringError
+import keyring.errors
 
 
 hookimpl = pluggy.HookimplMarker("devpiclient")
@@ -25,7 +24,7 @@ def restore_signature(func):
 
 @hookimpl()
 @restore_signature
-@suppress(KeyringError)
+@suppress(keyring.errors.KeyringError)
 def devpiclient_get_password(url, username):
     """
     >>> pluggy._hooks.varnames(devpiclient_get_password)

--- a/keyring/devpi_client.py
+++ b/keyring/devpi_client.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 
 import pluggy
 
@@ -15,6 +16,7 @@ suppress = type('suppress', (contextlib.suppress, contextlib.ContextDecorator), 
 
 def restore_signature(func):
     # workaround for pytest-dev/pluggy#358
+    @functools.wraps(func)
     def wrapper(url, username):
         return func(url, username)
 
@@ -28,5 +30,6 @@ def devpiclient_get_password(url, username):
     """
     >>> pluggy._hooks.varnames(devpiclient_get_password)
     (('url', 'username'), ())
+    >>>
     """
     return keyring.get_password(url, username)


### PR DESCRIPTION
- Add test to ensure varnames are calculated correctly. Ref #596.
- Add workaround for pytest-dev/pluggy#358. Fixes #596.
