### PR TITLE
libsecret: skip if there is no secret service running

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v23.11.0
+--------
+
+* #603: In ``libsecret``, check that the service is available before
+  declaring viability.
+
 v23.10.0
 --------
 


### PR DESCRIPTION
In case libsecret and its Python bindings are available the libsecret backend will get selected. This doesn't mean though that the system service it connects to is available.

This leads to the backend being used and then failing, for example in get_credential() with:
g-dbus-error-quark: The name org.freedesktop.secrets is unknown (2)

To avoid this ask libsecret to connect to the system service first before considering to use it.

Fixes #600