### PR TITLE
bugfix/573

### DIFF
--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -147,7 +147,7 @@ def find_generic_password(kc_name, service, username, not_found_ok=False):
 
 
 def set_generic_password(name, service, username, password):
-    if find_generic_password(name, service, username, not_found_ok=True):
+    if find_generic_password(name, service, username, not_found_ok=True) is not None:
         delete_generic_password(name, service, username)
 
     q = create_query(


### PR DESCRIPTION
per comment in #573, if user stores an empty string, it is returned to the if statement as `''`. in python, `''` evaluates as false, resulting in it not deleting the secret before trying to set a new one. this results in an error