### PR TITLE
Document full path of config path better

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,16 +140,16 @@ config file or by calling the ``set_keyring()`` function.
 Config file path
 ----------------
 
-The configuration is stored in a file named "keyringrc.cfg"
+The configuration is stored in a file named ``keyringrc.cfg``
 found in a platform-specific location. To determine
 where the config file is stored, run the following::
 
-    python -c "import keyring.util.platform_; print(keyring.util.platform_.config_root())"
+    python3 -c "import keyring.util.platform_; import os; print(os.path.join(keyring.util.platform_.config_root(), 'keyringrc.cfg'))"
 
 Some keyrings also store the keyring data in the file system.
 To determine where the data files are stored, run::
 
-    python -c "import keyring.util.platform_; print(keyring.util.platform_.data_root())"
+    python3 -c "import keyring.util.platform_; print(keyring.util.platform_.data_root())"
 
 Config file content
 -------------------


### PR DESCRIPTION
This is a small tweak. With the old documentation, I created a file named `/home/song/.config/python_keyring` and I wondered why it failed silently. I realise that I should have read the existing documentation more carefully. I think this change will make it even easier for users to find the configuration file.

On some systems with Python 3, only the `python3` executable is available (and not `python`), so I changed the executable to `python3` as well. This project doesn't support Python 2 any more.