### PR TITLE
Fix reading config file

### DIFF
--- a/keyring/core.py
+++ b/keyring/core.py
@@ -153,6 +153,7 @@ def _config_path():
 def _ensure_path(path):
     if not path.exists():
         raise FileNotFoundError(path)
+    return path
 
 
 def load_config() -> typing.Optional[backend.KeyringBackend]:

--- a/newsfragments/638.bugfix.rst
+++ b/newsfragments/638.bugfix.rst
@@ -1,0 +1,1 @@
+Restore support for reading from a config file (with regression test).

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,7 @@
 import keyring.core
+from unittest.mock import patch
+import pathlib
+import tempfile
 
 
 def test_init_recommended(monkeypatch):
@@ -10,5 +13,26 @@ def test_init_recommended(monkeypatch):
 
 
 def test_load_config_missing(caplog):
-    assert keyring.core.load_config() is None
-    assert not caplog.records
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = pathlib.Path(tmpdirname) / "keyringrc.cfg"
+        with patch.object(
+            keyring.core, '_config_path', return_value=path
+        ) as config_path_mock:
+            assert keyring.core.load_config() is None
+            assert not caplog.records
+
+        config_path_mock.assert_called_once()
+
+
+def test_load_config_exists(caplog):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = pathlib.Path(tmpdirname) / "keyringrc.cfg"
+        with open(path, "w", encoding='UTF-8') as file:
+            file.write('[backend]\ndefault-keyring=keyring.backends.fail.Keyring\n')
+        with patch.object(
+            keyring.core, '_config_path', return_value=path
+        ) as config_path_mock:
+            assert keyring.core.load_config() is not None
+            assert not caplog.records
+
+        config_path_mock.assert_called_once()


### PR DESCRIPTION
_ensure_path never returns a value causing the config file to never be read. Fix the existing test to ensure that the file it's looking for can't exist, add a new test that ensure the file does exist