### PR TITLE
Find password even with no username supplied in OSX backend

### DIFF
--- a/keyring/backends/macOS/__init__.py
+++ b/keyring/backends/macOS/__init__.py
@@ -57,9 +57,6 @@ class Keyring(KeyringBackend):
 
     @warn_keychain
     def get_password(self, service, username):
-        if username is None:
-            username = ''
-
         try:
             return api.find_generic_password(self.keychain, service, username)
         except api.NotFound:

--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -128,11 +128,13 @@ class SecAuthFailure(Error):
 
 
 def find_generic_password(kc_name, service, username, not_found_ok=False):
+    username_kwarg = {'kSecAttrAccount': username} if username is not None else {}
+        
     q = create_query(
         kSecClass=k_('kSecClassGenericPassword'),
         kSecMatchLimit=k_('kSecMatchLimitOne'),
         kSecAttrService=service,
-        kSecAttrAccount=username,
+        **username_kwarg,
         kSecReturnData=create_cfbool(True),
     )
 


### PR DESCRIPTION
Find a keyring password even if no username is supplied in the OS_X backend