### PR TITLE
Add argument to not output newline with "get"

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -42,7 +42,8 @@ class CommandLineTool:
             action="store_false",
             default=True,
             dest="include_newline",
-            help="Exclude newline from 'get' output")
+            help="Exclude newline from 'get' output",
+        )
         self.parser._operations = ["get", "set", "del", "diagnose"]
         self.parser.add_argument(
             'operation',

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -37,6 +37,12 @@ class CommandLineTool:
         self.parser.add_argument(
             "--disable", action="store_true", help="Disable keyring and exit"
         )
+        self.parser.add_argument(
+            "--no-newline",
+            action="store_false",
+            default=True,
+            dest="include_newline",
+            help="Exclude newline from 'get' output")
         self.parser._operations = ["get", "set", "del", "diagnose"]
         self.parser.add_argument(
             'operation',
@@ -84,7 +90,8 @@ class CommandLineTool:
         password = get_password(self.service, self.username)
         if password is None:
             raise SystemExit(1)
-        print(password)
+        end = None if self.include_newline else ""
+        print(password, end=end)
 
     def do_set(self):
         password = self.input_password(


### PR DESCRIPTION
This PR addresses #656 which I opened earlier today. It doesn't do anything with completion support; I have to confess that I do not know how that works.

While this could be more sophisticated (such as supporting a `--newline` for symmetry, to undo the effect of a prior `--no-newline`), this is enough to get started and for my own personal needs.