### PR TITLE
Remove useless shebang from cli.py

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Simple command line interface to get/set password from a keyring"""
 
 import getpass


### PR DESCRIPTION
This is to solve the following issue:
```
$ keyring/cli.py
Traceback (most recent call last):
  File "/opt/src/keyring/keyring/cli.py", line 8, in <module>
    from . import core
ImportError: attempted relative import with no known parent package
$
```