### PR TITLE
simplify and fix typing of priority()

### DIFF
--- a/keyring/_compat.py
+++ b/keyring/_compat.py
@@ -4,4 +4,4 @@ __all__ = ['properties']
 try:
     from jaraco.classes import properties  # pragma: no-cover
 except ImportError:
-    from . import _properties_compat as properties  # pragma: no-cover
+    from . import _properties_compat as properties  # type: ignore[no-redef] # pragma: no-cover

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -46,7 +46,7 @@ class KeyringBackend(metaclass=KeyringBackendMeta):
         self.set_properties_from_env()
 
     @properties.classproperty
-    def priority(self) -> typing.Union[int, float]:
+    def priority(self) -> float:
         """
         Each backend class must supply a priority, a number (float or integer)
         indicating the priority of the backend relative to all other backends.

--- a/keyring/backend.py
+++ b/keyring/backend.py
@@ -1,6 +1,7 @@
 """
 Keyring implementation support
 """
+
 from __future__ import annotations
 
 import os

--- a/keyring/backends/SecretService.py
+++ b/keyring/backends/SecretService.py
@@ -30,7 +30,7 @@ class Keyring(backend.SchemeSelectable, KeyringBackend):
     appid = 'Python keyring library'
 
     @properties.classproperty
-    def priority(cls) -> int:
+    def priority(cls) -> float:
         with ExceptionRaisedContext() as exc:
             secretstorage.__name__
         if exc:

--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -81,7 +81,7 @@ class WinVaultKeyring(KeyringBackend):
     persist = Persistence()
 
     @properties.classproperty
-    def priority(cls) -> int:
+    def priority(cls) -> float:
         """
         If available, the preferred backend on Windows.
         """

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -18,7 +18,7 @@ class ChainerBackend(backend.KeyringBackend):
     viable = True
 
     @properties.classproperty
-    def priority(cls) -> int:
+    def priority(cls) -> float:
         """
         If there are backends to chain, high priority
         Otherwise very low priority since our operation when empty

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -2,6 +2,7 @@
 Keyring Chainer - iterates over other viable backends to
 discover passwords in each.
 """
+
 from .. import backend
 from .._compat import properties
 from . import fail

--- a/keyring/backends/fail.py
+++ b/keyring/backends/fail.py
@@ -15,7 +15,7 @@ class Keyring(KeyringBackend):
     """
 
     @properties.classproperty
-    def priority(cls) -> int:
+    def priority(cls) -> float:
         return 0
 
     def get_password(self, service, username, password=None):

--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -82,9 +82,9 @@ def create_query(**kwargs):
     return CFDictionaryCreate(
         None,
         (c_void_p * len(kwargs))(*[k_(k) for k in kwargs.keys()]),
-        (c_void_p * len(kwargs))(
-            *[create_cfstr(v) if isinstance(v, str) else v for v in kwargs.values()]
-        ),
+        (c_void_p * len(kwargs))(*[
+            create_cfstr(v) if isinstance(v, str) else v for v in kwargs.values()
+        ]),
         len(kwargs),
         _found.kCFTypeDictionaryKeyCallBacks,
         _found.kCFTypeDictionaryValueCallBacks,

--- a/keyring/backends/null.py
+++ b/keyring/backends/null.py
@@ -11,7 +11,7 @@ class Keyring(KeyringBackend):
     """
 
     @properties.classproperty
-    def priority(cls) -> int:
+    def priority(cls) -> float:
         return -1
 
     def get_password(self, service, username, password=None):


### PR DESCRIPTION
as currently typed, mypy complains:
```
keyring/backends/fail.py:18: error: Signature of "priority" incompatible with supertype "KeyringBackend"  [override]
keyring/backends/fail.py:18: note:      Superclass:
keyring/backends/fail.py:18: note:          classproperty[float]
keyring/backends/fail.py:18: note:      Subclass:
keyring/backends/fail.py:18: note:          classproperty[int]
```
etc

but per https://peps.python.org/pep-0484/#the-numeric-tower, if you want `float | int`, `float`does just fine.  And now mypy is not unhappy with the typing of `priority()`.