### PR TITLE
feature: Add `get` options to cli for interface with `get_credential` and support JSON output

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -82,7 +82,10 @@ class CommandLineTool:
 
     def _check_args(self):
         if self.operation:
-            if self.service is None or (self.operation != "getcreds" and self.username is None):
+            if self.operation == 'getcreds':
+                if self.service is None :
+                    self.parser.error(f"{self.operation} requires service")
+            elif self.service is None or self.username is None:
                 self.parser.error(f"{self.operation} requires service and username")
 
     def do_get(self):

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -64,7 +64,7 @@ class CommandLineTool:
             dest="output_format",
             default="plain",
             help="""
-            Outpup format for 'get' operation.
+            Output format for 'get' operation.
 
             Default is 'plain'
             """,
@@ -127,7 +127,7 @@ class CommandLineTool:
             password = get_password(self.service, self.username)
             if password is None:
                 raise SystemExit(1)
-            crediential_dict['password'] = password
+            credential_dict['password'] = password
         if self.output_format == 'json':
             print(json.dumps(credential_dict))
         else:

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -116,24 +116,30 @@ class CommandLineTool:
                 self.parser.error(f"{self.operation} requires service and username")
 
     def do_get(self):
-        credential_dict = {}
-        if self.get_mode == 'creds':
-            creds = get_credential(self.service, self.username)
-            if creds is None:
-                raise SystemExit(1)
-            credential_dict['username'] = creds.username
-            credential_dict['password'] = creds.password
-        else:
-            password = get_password(self.service, self.username)
-            if password is None:
-                raise SystemExit(1)
-            credential_dict['password'] = password
+        credential_dict = getattr(self, f'_get_{self.get_mode}')()
         if self.output_format == 'json':
             print(json.dumps(credential_dict))
         else:
             if 'username' in credential_dict.keys():
                 print(credential_dict['username'])
             print(credential_dict['password'])
+
+    def _get_cred(self):
+        creds = get_credential(self.service, self.username)
+        if creds is None:
+            raise SystemExit(1)
+        credential_dict = {}
+        credential_dict['username'] = creds.username
+        credential_dict['password'] = creds.password
+        return credential_dict
+
+    def _get_password(self):
+        password = get_password(self.service, self.username)
+        if password is None:
+            raise SystemExit(1)
+        credential_dict = {}
+        credential_dict['password'] = password
+        return credential_dict
 
     def do_set(self):
         password = self.input_password(

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -42,7 +42,7 @@ class CommandLineTool:
         self.parser.add_argument(
             "--disable", action="store_true", help="Disable keyring and exit"
         )
-        self.parser._operations = ["get", "getcreds", "set", "del", "diagnose"] 
+        self.parser._operations = ["get", "set", "del", "getcreds", "diagnose"]
         self.parser.add_argument(
             'operation',
             choices=self.parser._operations,

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -45,7 +45,7 @@ class CommandLineTool:
         )
         self.parser._get_modes = ["password", "creds"]
         self.parser.add_argument(
-            "--get-mode",
+            "--mode",
             choices=self.parser._get_modes,
             dest="get_mode",
             default="password",

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -111,12 +111,10 @@ class CommandLineTool:
         return method()
 
     def _check_args(self):
-        if self.operation:
-            if self.operation == 'get' and self.get_mode == 'creds':
-                if self.service is None:
-                    self.parser.error(f"{self.operation} requires service")
-            elif self.service is None or self.username is None:
-                self.parser.error(f"{self.operation} requires service and username")
+        needs_username = self.operation != 'get' or self.get_mode != 'creds'
+        required = (['service'] + ['username'] * needs_username) * bool(self.operation)
+        if any(getattr(self, param) is None for param in required):
+            self.parser.error(f"{self.operation} requires {' and '.join(required)}")
 
     def do_get(self):
         credential = getattr(self, f'_get_{self.get_mode}')()

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -12,6 +12,7 @@ from . import (
     get_password,
     set_keyring,
     set_password,
+    get_credential,
 )
 from .util import platform_
 
@@ -41,7 +42,7 @@ class CommandLineTool:
         self.parser.add_argument(
             "--disable", action="store_true", help="Disable keyring and exit"
         )
-        self.parser._operations = ["get", "set", "del", "diagnose"]
+        self.parser._operations = ["get", "set", "del", "diagnose", "getcreds"]
         self.parser.add_argument(
             'operation',
             choices=self.parser._operations,
@@ -81,7 +82,7 @@ class CommandLineTool:
 
     def _check_args(self):
         if self.operation:
-            if self.service is None or self.username is None:
+            if self.service is None or (self.operation != "getcreds" && self.username is None):
                 self.parser.error(f"{self.operation} requires service and username")
 
     def do_get(self):
@@ -89,6 +90,13 @@ class CommandLineTool:
         if password is None:
             raise SystemExit(1)
         print(password)
+
+    def do_getcreds(self):
+        creds = get_credential(self.service, self.username)
+        if creds is None:
+            raise SystemExit(1)
+        print(f"username: {creds.username}")
+        print(f"password: {creds.password}")
 
     def do_set(self):
         password = self.input_password(

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -83,7 +83,7 @@ class CommandLineTool:
     def _check_args(self):
         if self.operation:
             if self.operation == 'getcreds':
-                if self.service is None :
+                if self.service is None:
                     self.parser.error(f"{self.operation} requires service")
             elif self.service is None or self.username is None:
                 self.parser.error(f"{self.operation} requires service and username")

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -42,7 +42,7 @@ class CommandLineTool:
         self.parser.add_argument(
             "--disable", action="store_true", help="Disable keyring and exit"
         )
-        self.parser._operations = ["get", "set", "del", "diagnose", "getcreds"]
+        self.parser._operations = ["get", "getcreds", "set", "del", "diagnose"] 
         self.parser.add_argument(
             'operation',
             choices=self.parser._operations,
@@ -82,7 +82,7 @@ class CommandLineTool:
 
     def _check_args(self):
         if self.operation:
-            if self.service is None or (self.operation != "getcreds" && self.username is None):
+            if self.service is None or (self.operation != "getcreds" and self.username is None):
                 self.parser.error(f"{self.operation} requires service and username")
 
     def do_get(self):

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import getpass
+import json
 import sys
 
 from . import (
@@ -56,6 +57,18 @@ class CommandLineTool:
             Default is 'password'
             """,
         )
+        self.parser._output_formats = ["plain", "json"]
+        self.parser.add_argument(
+            "--output",
+            choices=self.parser._output_formats,
+            dest="output_format",
+            default="plain",
+            help="""
+            Outpup format for 'get' operation.
+
+            Default is 'plain'
+            """,
+        )
         self.parser._operations = ["get", "set", "del", "diagnose"]
         self.parser.add_argument(
             'operation',
@@ -103,17 +116,24 @@ class CommandLineTool:
                 self.parser.error(f"{self.operation} requires service and username")
 
     def do_get(self):
+        credential_dict = {}
         if self.get_mode == 'creds':
             creds = get_credential(self.service, self.username)
             if creds is None:
                 raise SystemExit(1)
-            print(f"{creds.username}")
-            print(f"{creds.password}")
+            credential_dict['username'] = creds.username
+            credential_dict['password'] = creds.password
         else:
             password = get_password(self.service, self.username)
             if password is None:
                 raise SystemExit(1)
-            print(password)
+            crediential_dict['password'] = password
+        if self.output_format == 'json':
+            print(json.dumps(credential_dict))
+        else:
+            if 'username' in credential_dict.keys():
+                print(credential_dict['username'])
+            print(credential_dict['password'])
 
     def do_set(self):
         password = self.input_password(

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -117,12 +117,15 @@ class CommandLineTool:
 
     def do_get(self):
         credential_dict = getattr(self, f'_get_{self.get_mode}')()
-        if self.output_format == 'json':
-            print(json.dumps(credential_dict))
-        else:
-            if 'username' in credential_dict.keys():
-                print(credential_dict['username'])
-            print(credential_dict['password'])
+        getattr(self, f'_emit_{self.output_format}')(credential_dict)
+
+    def _emit_json(self, credential_dict):
+        print(json.dumps(credential_dict))
+
+    def _emit_plain(self, credential_dict):
+        if 'username' in credential_dict.keys():
+            print(credential_dict['username'])
+        print(credential_dict['password'])
 
     def _get_cred(self):
         creds = get_credential(self.service, self.username)

--- a/newsfragments/678.feature.rst
+++ b/newsfragments/678.feature.rst
@@ -1,0 +1,1 @@
+Added options for 'keyring get' command to support credential retrieval and emit as JSON.


### PR DESCRIPTION
Internally, `keyring` supports `get_credential`, which is useful for backends which can supply their own username.  This adds an exposed `get_credential` in the cli - `keyring --mode creds get [service] [OPTIONAL - username]`

This also adds support for JSON output type via `--output json` option

Help text for reference:

```text
  --output {plain,json}
                        Output format for 'get' operation. Default is 'plain'
  --mode {password,creds}
                        Mode for 'get' operation. 'password' requires a username and will return only the password.
                        'creds' does not require a username and will return both the username and password separated by
                        a newline. Default is 'password'
```

Example output:

```
 ➜  keyring --mode creds get https://example.com/
hello
world
 ➜  keyring --mode creds --output json get https://example.com/
{"username": "hello", "password": "world"}
 ➜  keyring --output json get https://example.com/ hello
{"password": "world"}
```