### PR TITLE
guard `WinVaultKeyring._get_password()` with `if missing_deps:`

### DIFF
--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -104,6 +104,8 @@ class WinVaultKeyring(KeyringBackend):
         return res.value
 
     def _get_password(self, target):
+        if missing_deps:
+            raise RuntimeError("Requires Windows and pywin32")
         try:
             res = win32cred.CredRead(
                 Type=win32cred.CRED_TYPE_GENERIC, TargetName=target


### PR DESCRIPTION
Separately, I need to figure out how I'm getting into this state, but from the other code it looks like this guard and explicit exception are the intended pattern for handling missing imports.  Though, it does seem that the traceback I am getting would be more useful.  But, I'll offer this up for consideration anyways.

https://github.com/Chia-Network/chia-blockchain/actions/runs/9372142688/job/25803038861?pr=18112#step:16:877
```
________________ test_keyring_dump_empty[empty, full, pretty] _________________
[gw1] win32 -- Python 3.10.11 D:\a\chia-blockchain\chia-blockchain\venv\scripts\python.exe
venv\lib\site-packages\keyring\backends\Windows.py:108: in _get_password
    res = win32cred.CredRead(
E   NameError: name 'win32cred' is not defined

During handling of the above exception, another exception occurred:
venv\lib\site-packages\chia\_tests\util\test_dump_keyring.py:55: in test_keyring_dump_empty
    result = runner.invoke(dump, [*case.args, os.fspath(keyring_path)], catch_exceptions=False)
venv\lib\site-packages\click\testing.py:408: in invoke
    return_value = cli.main(args=args or (), prog_name=prog_name, **extra)
venv\lib\site-packages\click\core.py:1055: in main
    rv = self.invoke(ctx)
venv\lib\site-packages\click\core.py:1404: in invoke
    return ctx.invoke(self.callback, **ctx.params)
venv\lib\site-packages\click\core.py:760: in invoke
    return __callback(*args, **kwargs)
venv\lib\site-packages\chia\util\dump_keyring.py:52: in dump
    saved_passphrase: Optional[str] = KeyringWrapper.get_shared_instance().get_master_passphrase_from_credential_store()
venv\lib\site-packages\chia\util\keyring_wrapper.py:256: in get_master_passphrase_from_credential_store
    return passphrase_store.get_password(  # type: ignore[no-any-return]
venv\lib\site-packages\keyring\backends\Windows.py:98: in get_password
    res = self._get_password(service)
venv\lib\site-packages\keyring\backends\Windows.py:111: in _get_password
    except pywintypes.error as e:
E   NameError: name 'pywintypes' is not defined
```