### PR TITLE
add a couple of type annotations

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -138,9 +138,7 @@ class CommandLineTool:
     def _get_password(self) -> credentials.Credential | None:
         password = get_password(self.service, self.username)  # type: ignore
         return (
-            credentials.SimpleCredential(None, password)
-            if password is not None
-            else None
+            credentials.AnonymousCredential(password) if password is not None else None
         )
 
     def do_set(self):

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -8,8 +8,7 @@ class Credential(metaclass=abc.ABCMeta):
     """Abstract class to manage credentials"""
 
     @abc.abstractproperty
-    def username(self) -> str | None:
-        return None
+    def username(self) -> str: ...
 
     @abc.abstractproperty
     def password(self) -> str: ...
@@ -18,17 +17,26 @@ class Credential(metaclass=abc.ABCMeta):
 class SimpleCredential(Credential):
     """Simple credentials implementation"""
 
-    def __init__(self, username: str | None, password: str):
+    def __init__(self, username: str, password: str):
         self._username = username
         self._password = password
 
     @property
-    def username(self) -> str | None:
+    def username(self) -> str:
         return self._username
 
     @property
     def password(self) -> str:
         return self._password
+
+
+class AnonymousCredential(SimpleCredential):
+    def __init__(self, password: str):
+        self._password = password
+
+    @property
+    def username(self) -> str:
+        raise ValueError("Anonymous credential has no username")
 
 
 class EnvironCredential(Credential):

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -12,14 +12,13 @@ class Credential(metaclass=abc.ABCMeta):
         return None
 
     @abc.abstractproperty
-    def password(self) -> str | None:
-        return None
+    def password(self) -> str: ...
 
 
 class SimpleCredential(Credential):
     """Simple credentials implementation"""
 
-    def __init__(self, username: str | None, password: str | None):
+    def __init__(self, username: str | None, password: str):
         self._username = username
         self._password = password
 
@@ -28,7 +27,7 @@ class SimpleCredential(Credential):
         return self._username
 
     @property
-    def password(self) -> str | None:
+    def password(self) -> str:
         return self._password
 
 

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import os
 
@@ -6,27 +8,27 @@ class Credential(metaclass=abc.ABCMeta):
     """Abstract class to manage credentials"""
 
     @abc.abstractproperty
-    def username(self):
+    def username(self) -> str | None:
         return None
 
     @abc.abstractproperty
-    def password(self):
+    def password(self) -> str | None:
         return None
 
 
 class SimpleCredential(Credential):
     """Simple credentials implementation"""
 
-    def __init__(self, username, password):
+    def __init__(self, username: str | None, password: str | None):
         self._username = username
         self._password = password
 
     @property
-    def username(self):
+    def username(self) -> str | None:
         return self._username
 
     @property
-    def password(self):
+    def password(self) -> str | None:
         return self._password
 
 
@@ -47,14 +49,14 @@ class EnvironCredential(Credential):
     False
     """
 
-    def __init__(self, user_env_var, pwd_env_var):
+    def __init__(self, user_env_var: str, pwd_env_var: str):
         self.user_env_var = user_env_var
         self.pwd_env_var = pwd_env_var
 
     def __eq__(self, other: object) -> bool:
         return vars(self) == vars(other)
 
-    def _get_env(self, env_var):
+    def _get_env(self, env_var: str) -> str:
         """Helper to read an environment variable"""
         value = os.environ.get(env_var)
         if not value:
@@ -62,9 +64,9 @@ class EnvironCredential(Credential):
         return value
 
     @property
-    def username(self):
+    def username(self) -> str:
         return self._get_env(self.user_env_var)
 
     @property
-    def password(self):
+    def password(self) -> str:
         return self._get_env(self.pwd_env_var)

--- a/newsfragments/689.feature.rst
+++ b/newsfragments/689.feature.rst
@@ -1,0 +1,1 @@
+Refined type spec and interfaces on credential objects. Introduced AnonymousCredential to model a secret without a username.


### PR DESCRIPTION
I ran into `untyped-call` warnings using the `SimpleCredential` - so here is a pull request adding annotations in `credentials.py`.

(There is a lot of unannotated code in this repository, I have no plans to do anything about the rest of it)