### PR TITLE
Not accessing `credentials.username` if `credentials` is an instance of `AnonymousCredential`

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -132,20 +132,11 @@ class CommandLineTool:
         getattr(self, f'_emit_{self.output_format}')(credential)
 
     def _emit_json(self, credential: credentials.Credential):
-        if isinstance(credential, credentials.AnonymousCredential):
-            print(json.dumps(dict(password=credential.password)))
-            return
-        print(
-            json.dumps(dict(username=credential.username, password=credential.password))
-        )
+        print(json.dumps(credential._vars()))
 
     def _emit_plain(self, credential: credentials.Credential):
-        if (
-            not isinstance(credential, credentials.AnonymousCredential)
-            and credential.username
-        ):
-            print(credential.username)
-        print(credential.password)
+        for val in credential._vars().values():
+            print(val)
 
     def _get_creds(self) -> credentials.Credential | None:
         return get_credential(self.service, self.username)

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -132,12 +132,18 @@ class CommandLineTool:
         getattr(self, f'_emit_{self.output_format}')(credential)
 
     def _emit_json(self, credential: credentials.Credential):
+        if isinstance(credential, credentials.AnonymousCredential):
+            print(json.dumps(dict(password=credential.password)))
+            return
         print(
             json.dumps(dict(username=credential.username, password=credential.password))
         )
 
     def _emit_plain(self, credential: credentials.Credential):
-        if credential.username:
+        if (
+            not isinstance(credential, credentials.AnonymousCredential)
+            and credential.username
+        ):
             print(credential.username)
         print(credential.password)
 

--- a/keyring/credentials.py
+++ b/keyring/credentials.py
@@ -13,6 +13,9 @@ class Credential(metaclass=abc.ABCMeta):
     @abc.abstractproperty
     def password(self) -> str: ...
 
+    def _vars(self) -> dict[str, str]:
+        return dict(username=self.username, password=self.password)
+
 
 class SimpleCredential(Credential):
     """Simple credentials implementation"""
@@ -37,6 +40,9 @@ class AnonymousCredential(SimpleCredential):
     @property
     def username(self) -> str:
         raise ValueError("Anonymous credential has no username")
+
+    def _vars(self) -> dict[str, str]:
+        return dict(password=self.password)
 
 
 class EnvironCredential(Credential):

--- a/newsfragments/694.bugfix.rst
+++ b/newsfragments/694.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ValueError for AnonymousCredentials in CLI.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,3 +83,15 @@ def test_get_anonymous(monkeypatch, mocked_get_credential, format, capsys):
     tool.output_format = format
     tool.do_get()
     assert 's3cret' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize('format', ['json', 'plain'])
+def test_get(monkeypatch, mocked_get_credential, format, capsys):
+    mocked_get_credential.return_value = credentials.SimpleCredential('alice', 's3cret')
+    tool = cli.CommandLineTool()
+    tool.service = 'svc'
+    tool.username = 'alice'
+    tool.get_mode = 'creds'
+    tool.output_format = format
+    tool.do_get()
+    assert 's3cret' in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from keyring import cli
+from keyring import credentials
 
 flatten = itertools.chain.from_iterable
 
@@ -36,6 +37,12 @@ def mocked_set():
         yield set_password
 
 
+@pytest.fixture
+def mocked_get_credential():
+    with mock.patch('keyring.cli.get_credential') as get_credential:
+        yield get_credential
+
+
 def test_set_interactive(monkeypatch, mocked_set):
     tool = cli.CommandLineTool()
     tool.service = 'svc'
@@ -64,3 +71,16 @@ def test_set_pipe_newline(monkeypatch, mocked_set):
     monkeypatch.setattr(sys.stdin, 'read', lambda: 'foo123\n')
     tool.do_set()
     mocked_set.assert_called_once_with('svc', 'usr', 'foo123')
+
+
+@pytest.mark.xfail(reason="#694")
+@pytest.mark.parametrize('format', ['json', 'plain'])
+def test_get_anonymous(monkeypatch, mocked_get_credential, format, capsys):
+    mocked_get_credential.return_value = credentials.AnonymousCredential('s3cret')
+    tool = cli.CommandLineTool()
+    tool.service = 'svc'
+    tool.username = None
+    tool.get_mode = 'creds'
+    tool.output_format = format
+    tool.do_get()
+    assert 's3cret' in capsys.readouterr().out


### PR DESCRIPTION
@jaraco this fixes #694 and #692

I think the consequences of #689 were missed.

I was not able to write a test to cover this case, so your help would be appreciated