### PR TITLE
Expand user home directory in config

### DIFF
--- a/keyring/core.py
+++ b/keyring/core.py
@@ -195,6 +195,6 @@ def _load_keyring_path(config: configparser.RawConfigParser) -> None:
     "load the keyring-path option (if present)"
     try:
         path = config.get("backend", "keyring-path").strip()
-        sys.path.insert(0, path)
+        sys.path.insert(0, os.path.expanduser(path))
     except (configparser.NoOptionError, configparser.NoSectionError):
         pass

--- a/newsfragments/696.feature.rst
+++ b/newsfragments/696.feature.rst
@@ -1,0 +1,1 @@
+When parsing ``keyring_path`` from the config, the home directory is now expanded from ``~``.


### PR DESCRIPTION
When reading the keyring_path from the config file, this would previously fail:

`keyring_path=~/foo/bar`

(it would need to be `/home/peterpan/foo/bar` or similar instead)

This commit fixes this issue by wrapping the path in `os.path.expanduser`