### PR TITLE
Don't log a warning when the `backend` config section is missing

### DIFF
--- a/keyring/core.py
+++ b/keyring/core.py
@@ -178,7 +178,7 @@ def load_config() -> typing.Optional[backend.KeyringBackend]:
         if config.has_section("backend"):
             keyring_name = config.get("backend", "default-keyring").strip()
         else:
-            raise configparser.NoOptionError('backend', 'default-keyring')
+            return None
 
     except (configparser.NoOptionError, ImportError):
         logger = logging.getLogger('keyring')

--- a/newsfragments/682.feature.rst
+++ b/newsfragments/682.feature.rst
@@ -1,0 +1,1 @@
+Avoid logging a warning when config does not specify a backend.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,6 +25,12 @@ def test_load_config_missing(caplog, config_path):
     assert not caplog.records
 
 
+def test_load_empty_config(caplog, config_path):
+    config_path.write_text("", encoding='utf-8')
+    assert keyring.core.load_config() is None
+    assert not caplog.records
+
+
 fail_config = textwrap.dedent(
     """
     [backend]


### PR DESCRIPTION
This config file is used by third party keyring backends, and setting one of *their* settings shouldn't give you a warning encouraging you to set `backend` setting.

This fixes https://github.com/jaraco/keyring/issues/682