### PR TITLE
Remove unused dependency jeepney

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,11 @@
+v25.7.0
+=======
+
+Bugfixes
+--------
+
+- Removed unused dependency ``jeepney``.
+
 v25.6.0
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ requires-python = ">=3.9"
 dependencies = [
 	'pywin32-ctypes>=0.2.0; sys_platform=="win32"',
 	'SecretStorage>=3.2; sys_platform=="linux"',
-	'jeepney>=0.4.2; sys_platform=="linux"',
 	'importlib_metadata >= 4.11.4; python_version < "3.12"',
 	"jaraco.classes",
 	'importlib_resources; python_version < "3.9"',


### PR DESCRIPTION
jeepney>=0.4.2 is listed as a dependency, but the README indicates that the jeepney backed was moved into a separate project. The dependency is not used directly any more either.

Remove the unused dependency completely.

See: https://gitlab.com/takluyver/keyring_jeepney