### PR TITLE
Update Windows.py correct delete password for username == None case

### DIFF
--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -149,7 +149,7 @@ class WinVaultKeyring(KeyringBackend):
         deleted = False
         for target in service, compound:
             existing_pw = self._read_credential(target)
-            if existing_pw and existing_pw['UserName'] == username:
+            if existing_pw and (username == None or existing_pw['UserName'] == username):
                 deleted = True
                 self._delete_password(target)
         if not deleted:


### PR DESCRIPTION
If username == None, the delete password can't find credentials entry. In this case we can't compare usernames and must remove credentials with all names.
Please review my proposal.