### PR TITLE
Add a couple of missing type hints

### DIFF
--- a/keyring/backends/Windows.py
+++ b/keyring/backends/Windows.py
@@ -92,7 +92,7 @@ class WinVaultKeyring(KeyringBackend):
         return 5
 
     @staticmethod
-    def _compound_name(username, service):
+    def _compound_name(username: str | None, service: str) -> str:
         return f'{username}@{service}'
 
     def get_password(self, service, username):

--- a/keyring/testing/backend.py
+++ b/keyring/testing/backend.py
@@ -25,7 +25,7 @@ UNICODE_CHARS = (
 assert min(ord(char) for char in UNICODE_CHARS) > 127
 
 
-def is_ascii_printable(s):
+def is_ascii_printable(s: str) -> bool:
     return all(32 <= ord(c) < 127 for c in s)
 
 
@@ -44,13 +44,13 @@ class BackendBasicTests:
         for item in self.credentials_created:
             self.keyring.delete_password(*item)
 
-    def set_password(self, service, username, password):
+    def set_password(self, service: str, username: str, password: str) -> None:
         # set the password and save the result so the test runner can clean
         #  up after if necessary.
         self.keyring.set_password(service, username, password)
         self.credentials_created.add((service, username))
 
-    def check_set_get(self, service, username, password):
+    def check_set_get(self, service: str, username: str, password: str) -> None:
         keyring = self.keyring
 
         # for the non-existent password

--- a/keyring/testing/util.py
+++ b/keyring/testing/util.py
@@ -63,6 +63,6 @@ def Environ(**changes):
 ALPHABET = string.ascii_letters + string.digits
 
 
-def random_string(k, source=ALPHABET):
+def random_string(k: int, source: str=ALPHABET) -> str:
     """Generate a random string with length <i>k</i>"""
     return ''.join(random.choice(source) for _unused in range(k))


### PR DESCRIPTION
This patch adds a couple of type hints for #661.

Running locally, this took `mypy --strict` from 391 errors to 338 errors.