### PR TITLE
Fix Ruff FA100, I001 and UP006 errors

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 import platform
 
-
 not_macOS = platform.system() != 'Darwin'
 
 collect_ignore = ["hook-keyring.backend.py"] + [

--- a/keyring/core.py
+++ b/keyring/core.py
@@ -2,6 +2,8 @@
 Core API functions and initialization routines.
 """
 
+from __future__ import annotations
+
 import configparser
 import logging
 import os
@@ -58,7 +60,7 @@ def disable() -> None:
         file.write('[backend]\ndefault-keyring=keyring.backends.null.Keyring')
 
 
-def get_password(service_name: str, username: str) -> typing.Optional[str]:
+def get_password(service_name: str, username: str) -> str | None:
     """Get password from the specified service."""
     return get_keyring().get_password(service_name, username)
 
@@ -74,8 +76,8 @@ def delete_password(service_name: str, username: str) -> None:
 
 
 def get_credential(
-    service_name: str, username: typing.Optional[str]
-) -> typing.Optional[credentials.Credential]:
+    service_name: str, username: str | None
+) -> credentials.Credential | None:
     """Get a Credential for the specified service."""
     return get_keyring().get_credential(service_name, username)
 
@@ -84,14 +86,14 @@ def recommended(backend) -> bool:
     return backend.priority >= 1
 
 
-def init_backend(limit: typing.Optional[LimitCallable] = None):
+def init_backend(limit: LimitCallable | None = None):
     """
     Load a detected backend.
     """
     set_keyring(_detect_backend(limit))
 
 
-def _detect_backend(limit: typing.Optional[LimitCallable] = None):
+def _detect_backend(limit: LimitCallable | None = None):
     """
     Return a keyring specified in the config file or infer the best available.
 
@@ -113,7 +115,7 @@ def _detect_backend(limit: typing.Optional[LimitCallable] = None):
     )
 
 
-def _load_keyring_class(keyring_name: str) -> typing.Type[backend.KeyringBackend]:
+def _load_keyring_class(keyring_name: str) -> type[backend.KeyringBackend]:
     """
     Load the keyring class indicated by name.
 
@@ -145,7 +147,7 @@ def load_keyring(keyring_name: str) -> backend.KeyringBackend:
     return class_()
 
 
-def load_env() -> typing.Optional[backend.KeyringBackend]:
+def load_env() -> backend.KeyringBackend | None:
     """Load a keyring configured in the environment variable."""
     try:
         return load_keyring(os.environ['PYTHON_KEYRING_BACKEND'])
@@ -163,7 +165,7 @@ def _ensure_path(path):
     return path
 
 
-def load_config() -> typing.Optional[backend.KeyringBackend]:
+def load_config() -> backend.KeyringBackend | None:
     """Load a keyring using the config file in the config root."""
 
     config = configparser.RawConfigParser()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,8 +5,7 @@ from unittest import mock
 
 import pytest
 
-from keyring import cli
-from keyring import credentials
+from keyring import cli, credentials
 
 flatten = itertools.chain.from_iterable
 


### PR DESCRIPTION
Fix failures on `main`:
```
=================================== FAILURES ===================================
_________________________________ test session _________________________________
conftest.py:1:1: I001 [*] Import block is un-sorted or un-formatted
  |
1 | import platform
  | ^^^^^^^^^^^^^^^ I001
  |
  = help: Organize imports


_________________________________ test session _________________________________
keyring/core.py:61:55: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
61 | def get_password(service_name: str, username: str) -> typing.Optional[str]:
   |                                                       ^^^^^^^^^^^^^^^ FA100
62 |     """Get password from the specified service."""
63 |     return get_keyring().get_password(service_name, username)
   |

keyring/core.py:77:34: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
76 | def get_credential(
77 |     service_name: str, username: typing.Optional[str]
   |                                  ^^^^^^^^^^^^^^^ FA100
78 | ) -> typing.Optional[credentials.Credential]:
79 |     """Get a Credential for the specified service."""
   |

keyring/core.py:78:6: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
76 | def get_credential(
77 |     service_name: str, username: typing.Optional[str]
78 | ) -> typing.Optional[credentials.Credential]:
   |      ^^^^^^^^^^^^^^^ FA100
79 |     """Get a Credential for the specified service."""
80 |     return get_keyring().get_credential(service_name, username)
   |

keyring/core.py:87:25: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
87 | def init_backend(limit: typing.Optional[LimitCallable] = None):
   |                         ^^^^^^^^^^^^^^^ FA100
88 |     """
89 |     Load a detected backend.
   |

keyring/core.py:94:28: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
   |
94 | def _detect_backend(limit: typing.Optional[LimitCallable] = None):
   |                            ^^^^^^^^^^^^^^^ FA100
95 |     """
96 |     Return a keyring specified in the config file or infer the best available.
   |

keyring/core.py:116:47: UP006 Use `type` instead of `typing.Type` for type annotation
    |
116 | def _load_keyring_class(keyring_name: str) -> typing.Type[backend.KeyringBackend]:
    |                                               ^^^^^^^^^^^ UP006
117 |     """
118 |     Load the keyring class indicated by name.
    |
    = help: Replace with `type`

keyring/core.py:148:19: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
    |
148 | def load_env() -> typing.Optional[backend.KeyringBackend]:
    |                   ^^^^^^^^^^^^^^^ FA100
149 |     """Load a keyring configured in the environment variable."""
150 |     try:
    |

keyring/core.py:166:22: FA100 Add `from __future__ import annotations` to simplify `typing.Optional`
    |
166 | def load_config() -> typing.Optional[backend.KeyringBackend]:
    |                      ^^^^^^^^^^^^^^^ FA100
167 |     """Load a keyring using the config file in the config root."""
    |


_________________________________ test session _________________________________
tests/test_cli.py:1:1: I001 [*] Import block is un-sorted or un-formatted
   |
 1 | / import getpass
 2 | | import itertools
 3 | | import sys
 4 | | from unittest import mock
 5 | |
 6 | | import pytest
 7 | |
 8 | | from keyring import cli
 9 | | from keyring import credentials
   | |_______________________________^ I001
10 |
11 |   flatten = itertools.chain.from_iterable
   |
   = help: Organize imports
```
https://github.com/jaraco/keyring/actions/runs/15014236777/job/42188495940