### PR TITLE
Remove importlib_resources for Python 3.8

### DIFF
--- a/keyring/compat/py38.py
+++ b/keyring/compat/py38.py
@@ -1,9 +1,0 @@
-import sys
-
-__all__ = ['files']
-
-
-if sys.version_info < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files

--- a/keyring/completion.py
+++ b/keyring/completion.py
@@ -1,12 +1,11 @@
 import argparse
 import sys
+from importlib.resources import files
 
 try:
     import shtab
 except ImportError:
     pass
-
-from .compat.py38 import files
 
 
 class _MissingCompletionAction(argparse.Action):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
 	'jeepney>=0.4.2; sys_platform=="linux"',
 	'importlib_metadata >= 4.11.4; python_version < "3.12"',
 	"jaraco.classes",
-	'importlib_resources; python_version < "3.9"',
 	"jaraco.functools",
 	"jaraco.context",
 ]


### PR DESCRIPTION
Python 3.8 is EOL and support has been removed from keyring.

This PR removes some old compatibility code.

---

Also contains https://github.com/jaraco/keyring/pull/721 to fix CI.

