### PR TITLE
feat: Add list passwords for MacOS Keychain

### DIFF
--- a/keyring/backends/macOS/__init__.py
+++ b/keyring/backends/macOS/__init__.py
@@ -41,6 +41,13 @@ class Keyring(KeyringBackend):
         return 5
 
     @warn_keychain
+    def list_passwords(self):
+        try:
+            return api.list_generic_passwords()
+        except api.Error as e:
+            raise KeyringError(f"Can't list passwords in keychain: {e}") from e
+
+    @warn_keychain
     def set_password(self, service, username, password):
         if username is None:
             username = ''

--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -63,6 +63,15 @@ CFDictionaryCreate.argtypes = (
     c_void_p,
 )
 
+CFStringGetCStringPtr = _found.CFStringGetCStringPtr
+CFStringGetCStringPtr.restype = ctypes.c_char_p
+CFStringGetCStringPtr.argtypes = [c_void_p, c_uint32]
+kCFStringEncodingUTF8 = 0x08000100
+
+CFStringGetCString = _found.CFStringGetCString
+CFStringGetCString.restype = ctypes.c_bool
+CFStringGetCString.argtypes = [c_void_p, ctypes.c_char_p, c_int32, c_uint32]
+
 CFStringCreateWithCString = _found.CFStringCreateWithCString
 CFStringCreateWithCString.restype = c_void_p
 CFStringCreateWithCString.argtypes = [c_void_p, c_void_p, c_uint32]
@@ -142,18 +151,9 @@ def cfdata_to_str(data):
 def cfstring_to_str(cfstring):
     if not cfstring:
         return None
-    # Try fast path
-    CFStringGetCStringPtr = _found.CFStringGetCStringPtr
-    CFStringGetCStringPtr.restype = ctypes.c_char_p
-    CFStringGetCStringPtr.argtypes = [c_void_p, c_uint32]
-    kCFStringEncodingUTF8 = 0x08000100
     cstr = CFStringGetCStringPtr(cfstring, kCFStringEncodingUTF8)
     if cstr:
         return cstr.decode("utf-8")
-    # Fallback: use buffer
-    CFStringGetCString = _found.CFStringGetCString
-    CFStringGetCString.restype = ctypes.c_bool
-    CFStringGetCString.argtypes = [c_void_p, ctypes.c_char_p, c_int32, c_uint32]
     buf = ctypes.create_string_buffer(1024)
     if CFStringGetCString(cfstring, buf, 1024, kCFStringEncodingUTF8):
         return buf.value.decode("utf-8")

--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -22,9 +22,35 @@ class error:
     sec_interaction_not_allowed = -25308
 
 
-_sec = ctypes.CDLL(find_library('Security'))
-_core = ctypes.CDLL(find_library('CoreServices'))
-_found = ctypes.CDLL(find_library('Foundation'))
+_sec = ctypes.CDLL(find_library("Security"))
+_core = ctypes.CDLL(find_library("CoreServices"))
+_found = ctypes.CDLL(find_library("Foundation"))
+
+CFGetTypeID = _found.CFGetTypeID
+CFGetTypeID.restype = c_uint32
+CFGetTypeID.argtypes = [c_void_p]
+
+CFArrayGetTypeID = _found.CFArrayGetTypeID
+CFArrayGetTypeID.restype = c_uint32
+
+CFAttributedStringGetTypeID = _found.CFAttributedStringGetTypeID
+CFAttributedStringGetTypeID.restype = c_uint32
+
+CFCopyTypeIDDescription = _found.CFCopyTypeIDDescription
+CFCopyTypeIDDescription.restype = c_void_p
+CFCopyTypeIDDescription.argtypes = [c_uint32]
+
+CFArrayGetCount = _found.CFArrayGetCount
+CFArrayGetCount.restype = c_int32
+CFArrayGetCount.argtypes = [c_void_p]
+
+CFArrayGetValueAtIndex = _found.CFArrayGetValueAtIndex
+CFArrayGetValueAtIndex.restype = c_void_p
+CFArrayGetValueAtIndex.argtypes = [c_void_p, c_int32]
+
+CFDictionaryGetValue = _found.CFDictionaryGetValue
+CFDictionaryGetValue.restype = c_void_p
+CFDictionaryGetValue.argtypes = [c_void_p, c_void_p]
 
 CFDictionaryCreate = _found.CFDictionaryCreate
 CFDictionaryCreate.restype = c_void_p
@@ -88,7 +114,7 @@ def _(val: bool | int):
 @create_cf.register
 def _(s: str):
     kCFStringEncodingUTF8 = 0x08000100
-    return CFStringCreateWithCString(None, s.encode('utf8'), kCFStringEncodingUTF8)
+    return CFStringCreateWithCString(None, s.encode("utf8"), kCFStringEncodingUTF8)
 
 
 def create_query(**kwargs):
@@ -102,10 +128,36 @@ def create_query(**kwargs):
     )
 
 
-def cfstr_to_str(data):
-    return ctypes.string_at(CFDataGetBytePtr(data), CFDataGetLength(data)).decode(
-        'utf-8'
-    )
+# Convert CFDataRef to Python str
+def cfdata_to_str(data):
+    b = ctypes.string_at(CFDataGetBytePtr(data), CFDataGetLength(data))
+    try:
+        return b.decode("utf-8")
+    except UnicodeDecodeError:
+        # Return hex string if not valid UTF-8
+        return b.hex()
+
+
+# Convert CFStringRef to Python str
+def cfstring_to_str(cfstring):
+    if not cfstring:
+        return None
+    # Try fast path
+    CFStringGetCStringPtr = _found.CFStringGetCStringPtr
+    CFStringGetCStringPtr.restype = ctypes.c_char_p
+    CFStringGetCStringPtr.argtypes = [c_void_p, c_uint32]
+    kCFStringEncodingUTF8 = 0x08000100
+    cstr = CFStringGetCStringPtr(cfstring, kCFStringEncodingUTF8)
+    if cstr:
+        return cstr.decode("utf-8")
+    # Fallback: use buffer
+    CFStringGetCString = _found.CFStringGetCString
+    CFStringGetCString.restype = ctypes.c_bool
+    CFStringGetCString.argtypes = [c_void_p, ctypes.c_char_p, c_int32, c_uint32]
+    buf = ctypes.create_string_buffer(1024)
+    if CFStringGetCString(cfstring, buf, 1024, kCFStringEncodingUTF8):
+        return buf.value.decode("utf-8")
+    return None
 
 
 class Error(Exception):
@@ -140,8 +192,8 @@ class SecAuthFailure(Error):
 
 def find_generic_password(kc_name, service, username, not_found_ok=False):
     q = create_query(
-        kSecClass=k_('kSecClassGenericPassword'),
-        kSecMatchLimit=k_('kSecMatchLimitOne'),
+        kSecClass=k_("kSecClassGenericPassword"),
+        kSecMatchLimit=k_("kSecMatchLimitOne"),
         kSecAttrService=service,
         kSecAttrAccount=username,
         kSecReturnData=True,
@@ -155,7 +207,7 @@ def find_generic_password(kc_name, service, username, not_found_ok=False):
 
     Error.raise_for_status(status)
 
-    return cfstr_to_str(data)
+    return cfdata_to_str(data)
 
 
 def set_generic_password(name, service, username, password):
@@ -163,7 +215,7 @@ def set_generic_password(name, service, username, password):
         delete_generic_password(name, service, username)
 
     q = create_query(
-        kSecClass=k_('kSecClassGenericPassword'),
+        kSecClass=k_("kSecClassGenericPassword"),
         kSecAttrService=service,
         kSecAttrAccount=username,
         kSecValueData=password,
@@ -175,10 +227,53 @@ def set_generic_password(name, service, username, password):
 
 def delete_generic_password(name, service, username):
     q = create_query(
-        kSecClass=k_('kSecClassGenericPassword'),
+        kSecClass=k_("kSecClassGenericPassword"),
         kSecAttrService=service,
         kSecAttrAccount=username,
     )
 
     status = SecItemDelete(q)
     Error.raise_for_status(status)
+
+
+def list_generic_passwords():
+    q = create_query(
+        kSecClass=k_("kSecClassGenericPassword"),
+        kSecMatchLimit=k_("kSecMatchLimitAll"),
+        kSecReturnAttributes=True,
+    )
+
+    result = ctypes.pointer(c_void_p())
+    status = SecItemCopyMatching(q, result)
+
+    if status == error.item_not_found:
+        return []
+
+    Error.raise_for_status(status)
+
+    kSecAttrService = k_("kSecAttrService")
+    kSecAttrAccount = k_("kSecAttrAccount")
+
+    cf_result = result.contents.value
+    if not cf_result:
+        return []
+
+    if CFGetTypeID(cf_result) == CFArrayGetTypeID():
+        count = CFArrayGetCount(cf_result)
+        dicts = [CFArrayGetValueAtIndex(cf_result, i) for i in range(count)]
+    else:
+        dicts = [cf_result]
+
+    items: list[dict[str, str | None]] = []
+    for d in dicts:
+        service_cf = CFDictionaryGetValue(d, kSecAttrService)
+        account_cf = CFDictionaryGetValue(d, kSecAttrAccount)
+
+        items.append(
+            {
+                "service": cfstring_to_str(service_cf),
+                "account": cfstring_to_str(account_cf),
+            }
+        )
+
+    return items

--- a/tests/backends/test_macOS.py
+++ b/tests/backends/test_macOS.py
@@ -2,6 +2,7 @@ import pytest
 
 import keyring
 from keyring.backends import macOS
+from keyring.testing.util import random_string
 from keyring.testing.backend import BackendBasicTests
 
 
@@ -12,3 +13,21 @@ from keyring.testing.backend import BackendBasicTests
 class Test_macOSKeychain(BackendBasicTests):
     def init_keyring(self):
         return macOS.Keyring()
+
+    def test_list_generic_passwords(self):
+        service = random_string(20)
+        account = random_string(20)
+        password = "non-blank"
+
+        macOS.api.set_generic_password(None, service, account, password)
+
+        items = macOS.api.list_generic_passwords()
+
+        found = [
+            item
+            for item in items
+            if item["service"] == service and item["account"] == account
+        ]
+        assert found, f"No item found for service={service} and account={account}"
+
+        macOS.api.delete_generic_password(None, service, account)


### PR DESCRIPTION
## Context

This pull request introduces a new feature to the macOS backend of the keyring library, enabling users to list all generic passwords stored in the keychain.

## Key Changes

### New Method Added

1. `list_passwords` method is added to `macOS.Keyring`, allowing retrieval of all generic passwords.
2. This method uses the new `api.list_generic_passwords()` function.

### API Enhancements

Implements `list_generic_passwords()` in `macOS/api.py`, which:
1. Queries the keychain for all generic password items.
2. Returns a list of dictionaries containing the service and account for each item.
3. Adds helpers for converting CoreFoundation types (`CFStringRef`, `CFDataRef`) to Python strings for easier handling of keychain data.

### Testing

A new test `test_list_generic_passwords` in `tests/backends/test_macOS.py` verifies:
1. The password listing functionality.
2. That passwords added by the test can be successfully found and then cleaned up.

## Impact

- **User Benefit:** macOS users can now programmatically list all generic passwords in their keychain using keyring’s API.
- **Testing:** The feature is covered by new automated tests.
- **Backward Compatibility:** Changes are additive and should not affect existing functionality.

TLDR; This PR enhances the macOS backend by adding password listing capability, improves type conversions, and provides robust tests for the new functionality.