### PR TITLE
Add instructions for using Keyring with tox for pip credentials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -382,16 +382,17 @@ The following is a complete transcript for installing keyring on a Ubuntu 18:04 
 Using Keyring with tox on Linux systems for pip credentials 
 =============================================================
 
-When using Keyring to store credentials for pip, you may encounter the following error  when
+When using Keyring to store credentials for pip, you may encounter the following error when
 running tests under ``tox``:
 
   RuntimeError: No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.
 
-This can be caused by Keyring not knowing where D-Bus is located, as ``tox`` does not pass 
-through the required environment variables.
+This can be caused by Keyring not knowing the address for D-Bus, as ``tox`` does not pass 
+through the required environment variables by default.
+
 This can be resolved by adding ``DBUS_SESSION_BUS_ADDRESS`` to ``pass_env`` in your 
 ``tox`` configuration. You may additionally need to add ``DISPLAY`` and ``WAYLAND_DISPLAY`` 
-to ``pass_env`` for ``pinentry`` to get confirmation.
+to ``pass_env`` to enable ``pinentry`` to get confirmation.
 
 Integration
 ===========

--- a/README.rst
+++ b/README.rst
@@ -379,20 +379,19 @@ The following is a complete transcript for installing keyring on a Ubuntu 18:04 
   >>> keyring.get_password("system", "username")
   'password'
 
-Using Keyring with tox on Linux systems for pip credentials 
-=============================================================
+Using Keyring with tox on Linux systems for pip credentials
+===========================================================
 
-When using Keyring to store credentials for pip, you may encounter the following error when
+When using Keyring to store credentials for pip, one may encounter the following error when
 running tests under ``tox``:
 
   RuntimeError: No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.
 
-This can be caused by Keyring not knowing the address for D-Bus, as ``tox`` does not pass 
-through the required environment variables by default.
+This error is caused by Keyring not knowing the address for D-Bus, as ``tox`` filters
+by default the required environment variables.
 
-This can be resolved by adding ``DBUS_SESSION_BUS_ADDRESS`` to ``pass_env`` in your 
-``tox`` configuration. You may additionally need to add ``DISPLAY`` and ``WAYLAND_DISPLAY`` 
-to ``pass_env`` to enable ``pinentry`` to get confirmation.
+To work around the issue, add ``DBUS_SESSION_BUS_ADDRESS`` to ``pass_env`` in the
+``tox`` configuration. Consider adding other necessary variables, such as ``DISPLAY`` and ``WAYLAND_DISPLAY`` (if using ``pinentry``).
 
 Integration
 ===========

--- a/README.rst
+++ b/README.rst
@@ -379,16 +379,17 @@ The following is a complete transcript for installing keyring on a Ubuntu 18:04 
   >>> keyring.get_password("system", "username")
   'password'
 
-Using Keyring with tox on Linux systems for pip credentials
-===========================================================
+Using Keyring with tox
+======================
 
-When using Keyring to store credentials for pip, one may encounter the following error when
-running tests under ``tox``:
+Some backends rely on environment variables to operate correctly, and ``tox`` filters most environment variables by default.
+
+For example, when using Keyring to store credentials for pip, one may encounter the following error when
+running tests under ``tox`` when using a backend reliant on D-Bus:
 
   RuntimeError: No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.
 
-This error is caused by Keyring not knowing the address for D-Bus, as ``tox`` filters
-by default the required environment variables.
+This error is caused by Keyring KWallet backend not able to resolve the backing service.
 
 To work around the issue, add ``DBUS_SESSION_BUS_ADDRESS`` to ``pass_env`` in the
 ``tox`` configuration. Consider adding other necessary variables, such as ``DISPLAY`` and ``WAYLAND_DISPLAY`` (if using ``pinentry``).

--- a/README.rst
+++ b/README.rst
@@ -379,6 +379,20 @@ The following is a complete transcript for installing keyring on a Ubuntu 18:04 
   >>> keyring.get_password("system", "username")
   'password'
 
+Using Keyring with tox on Linux systems for pip credentials 
+=============================================================
+
+When using Keyring to store credentials for pip, you may encounter the following error  when
+running tests under ``tox``:
+
+  RuntimeError: No recommended backend was available. Install the keyrings.alt package if you want to use the non-recommended backends. See README.rst for details.
+
+This can be caused by Keyring not knowing where D-Bus is located, as ``tox`` does not pass 
+through the required environment variables.
+This can be resolved by adding ``DBUS_SESSION_BUS_ADDRESS`` to ``pass_env`` in your 
+``tox`` configuration. You may additionally need to add ``DISPLAY`` and ``WAYLAND_DISPLAY`` 
+to ``pass_env`` for ``pinentry`` to get confirmation.
+
 Integration
 ===========
 


### PR DESCRIPTION
Adds instructions to the Readme for how to deal with issues when using Keyring with tox for pip credentials. See #283 for context.