### PR TITLE
Fix crash with KWallet 6

### DIFF
--- a/keyring/backends/kwallet.py
+++ b/keyring/backends/kwallet.py
@@ -46,7 +46,7 @@ class DBusKeyring(KeyringBackend):
             raise RuntimeError(exc.get_dbus_message()) from exc
         if not (
             bus.name_has_owner(cls.bus_name)
-            or cls.bus_name in bus.list_activatable_names()
+            and cls.bus_name in bus.list_activatable_names()
         ):
             raise RuntimeError(
                 "The KWallet daemon is neither running nor activatable through D-Bus"

--- a/newsfragments/728.feature.rst
+++ b/newsfragments/728.feature.rst
@@ -1,0 +1,1 @@
+Improved support for KWallet 6.


### PR DESCRIPTION
Hi, this fixes #726.

This occurs because `org.kde.kwalletd` is still seemingly an owner, but not an activatable name with KWallet 6, and this causes a crash when keyring tries to open `/modules/kwalletd` which doesn't exist.

This works for KWallet 6, but this hasn't been tested with KWallet 5 & 4.

Thanks,
Steve