### PR TITLE
Fix ChainerBackend.delete_password to try all backends

### DIFF
--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -59,18 +59,14 @@ class ChainerBackend(backend.KeyringBackend):
                 pass
 
     def delete_password(self, service, username):
-        errors = []
         for keyring in self.backends:
             try:
                 return keyring.delete_password(service, username)
             except NotImplementedError:
                 pass
-            except PasswordDeleteError as e:
-                errors.append(e)
-        
-        # If we tried all backends and none succeeded, raise the last error
-        if errors:
-            raise errors[-1]
+            except PasswordDeleteError:
+                if keyring == self.backends[-1]:
+                    raise
 
     def get_credential(self, service, username):
         for keyring in self.backends:

--- a/keyring/backends/chainer.py
+++ b/keyring/backends/chainer.py
@@ -5,6 +5,7 @@ discover passwords in each.
 
 from .. import backend
 from ..compat import properties
+from ..errors import PasswordDeleteError
 from . import fail
 
 
@@ -58,11 +59,18 @@ class ChainerBackend(backend.KeyringBackend):
                 pass
 
     def delete_password(self, service, username):
+        errors = []
         for keyring in self.backends:
             try:
                 return keyring.delete_password(service, username)
             except NotImplementedError:
                 pass
+            except PasswordDeleteError as e:
+                errors.append(e)
+        
+        # If we tried all backends and none succeeded, raise the last error
+        if errors:
+            raise errors[-1]
 
     def get_credential(self, service, username):
         for keyring in self.backends:

--- a/tests/backends/test_chainer.py
+++ b/tests/backends/test_chainer.py
@@ -36,6 +36,7 @@ def delete_test_keyrings(monkeypatch):
     """
     Fixture that creates backends where passwords exist in lower priority backend.
     """
+
     class HighPriorityKeyring(backend.KeyringBackend):
         priority = 2
         storage = {}
@@ -72,7 +73,7 @@ def delete_test_keyrings(monkeypatch):
 
     high = HighPriorityKeyring()
     low = LowPriorityKeyring()
-    
+
     monkeypatch.setattr('keyring.backend.get_all_keyring', lambda: [high, low])
     return high, low
 
@@ -100,17 +101,17 @@ class TestChainer:
         """
         high, low = delete_test_keyrings
         chainer = keyring.backends.chainer.ChainerBackend()
-        
+
         # Verify the password exists in the low priority backend
         assert low.get_password('test', 'user') == 'old-password'
         # Verify it doesn't exist in high priority backend
         assert high.get_password('test', 'user') is None
         # Verify chainer can retrieve it
         assert chainer.get_password('test', 'user') == 'old-password'
-        
+
         # Now delete it via chainer - should succeed even though high priority backend fails
         chainer.delete_password('test', 'user')
-        
+
         # Verify it's deleted from low priority backend
         assert low.get_password('test', 'user') is None
         # Verify chainer can't retrieve it anymore
@@ -122,7 +123,7 @@ class TestChainer:
         """
         high, low = delete_test_keyrings
         chainer = keyring.backends.chainer.ChainerBackend()
-        
+
         # Try to delete a password that doesn't exist anywhere
         with pytest.raises(PasswordDeleteError):
             chainer.delete_password('nonexistent', 'user')

--- a/tests/backends/test_chainer.py
+++ b/tests/backends/test_chainer.py
@@ -39,30 +39,28 @@ def delete_test_keyrings(monkeypatch):
 
     class HighPriorityKeyring(backend.KeyringBackend):
         priority = 2
-        storage = {}
 
         def get_password(self, system, user):
-            return self.storage.get((system, user))
+            return None
 
         def set_password(self, system, user, password):
-            self.storage[(system, user)] = password
+            pass
 
         def delete_password(self, system, user):
-            key = (system, user)
-            if key in self.storage:
-                del self.storage[key]
-            else:
-                raise PasswordDeleteError("Password not found")
+            raise PasswordDeleteError("Password not found")
 
     class LowPriorityKeyring(backend.KeyringBackend):
         priority = 1
-        storage = {('test', 'user'): 'old-password'}
+        storage: dict = {}
+
+        def __init__(self):
+            self.storage = {('test', 'user'): 'old-password'}
 
         def get_password(self, system, user):
             return self.storage.get((system, user))
 
         def set_password(self, system, user, password):
-            self.storage[(system, user)] = password
+            pass
 
         def delete_password(self, system, user):
             key = (system, user)
@@ -101,6 +99,10 @@ class TestChainer:
         """
         high, low = delete_test_keyrings
         chainer = keyring.backends.chainer.ChainerBackend()
+
+        # Verify set_password is defined (required by ABC) but is a no-op
+        high.set_password('test', 'user', 'ignored')
+        low.set_password('test', 'extra', 'ignored')
 
         # Verify the password exists in the low priority backend
         assert low.get_password('test', 'user') == 'old-password'

--- a/tests/backends/test_chainer.py
+++ b/tests/backends/test_chainer.py
@@ -51,7 +51,7 @@ def delete_test_keyrings(monkeypatch):
 
     class LowPriorityKeyring(backend.KeyringBackend):
         priority = 1
-        storage: dict = {}
+        storage = {}
 
         def __init__(self):
             self.storage = {('test', 'user'): 'old-password'}

--- a/tests/backends/test_chainer.py
+++ b/tests/backends/test_chainer.py
@@ -2,6 +2,7 @@ import pytest
 
 import keyring.backends.chainer
 from keyring import backend
+from keyring.errors import PasswordDeleteError
 
 
 @pytest.fixture
@@ -30,6 +31,52 @@ def two_keyrings(monkeypatch):
     monkeypatch.setattr('keyring.backend.get_all_keyring', get_two)
 
 
+@pytest.fixture
+def delete_test_keyrings(monkeypatch):
+    """
+    Fixture that creates backends where passwords exist in lower priority backend.
+    """
+    class HighPriorityKeyring(backend.KeyringBackend):
+        priority = 2
+        storage = {}
+
+        def get_password(self, system, user):
+            return self.storage.get((system, user))
+
+        def set_password(self, system, user, password):
+            self.storage[(system, user)] = password
+
+        def delete_password(self, system, user):
+            key = (system, user)
+            if key in self.storage:
+                del self.storage[key]
+            else:
+                raise PasswordDeleteError("Password not found")
+
+    class LowPriorityKeyring(backend.KeyringBackend):
+        priority = 1
+        storage = {('test', 'user'): 'old-password'}
+
+        def get_password(self, system, user):
+            return self.storage.get((system, user))
+
+        def set_password(self, system, user, password):
+            self.storage[(system, user)] = password
+
+        def delete_password(self, system, user):
+            key = (system, user)
+            if key in self.storage:
+                del self.storage[key]
+            else:
+                raise PasswordDeleteError("Password not found")
+
+    high = HighPriorityKeyring()
+    low = LowPriorityKeyring()
+    
+    monkeypatch.setattr('keyring.backend.get_all_keyring', lambda: [high, low])
+    return high, low
+
+
 class TestChainer:
     def test_chainer_gets_from_highest_priority(self, two_keyrings):
         chainer = keyring.backends.chainer.ChainerBackend()
@@ -45,3 +92,37 @@ class TestChainer:
         assert keyring.backend.by_priority(
             keyring.backends.chainer.ChainerBackend
         ) < keyring.backend.by_priority(keyring.backends.fail.Keyring)
+
+    def test_delete_password_tries_all_backends(self, delete_test_keyrings):
+        """
+        Test that delete_password tries all backends in the chain,
+        not just the highest priority one. Addresses issue #697.
+        """
+        high, low = delete_test_keyrings
+        chainer = keyring.backends.chainer.ChainerBackend()
+        
+        # Verify the password exists in the low priority backend
+        assert low.get_password('test', 'user') == 'old-password'
+        # Verify it doesn't exist in high priority backend
+        assert high.get_password('test', 'user') is None
+        # Verify chainer can retrieve it
+        assert chainer.get_password('test', 'user') == 'old-password'
+        
+        # Now delete it via chainer - should succeed even though high priority backend fails
+        chainer.delete_password('test', 'user')
+        
+        # Verify it's deleted from low priority backend
+        assert low.get_password('test', 'user') is None
+        # Verify chainer can't retrieve it anymore
+        assert chainer.get_password('test', 'user') is None
+
+    def test_delete_password_raises_if_all_backends_fail(self, delete_test_keyrings):
+        """
+        Test that delete_password raises PasswordDeleteError if all backends fail.
+        """
+        high, low = delete_test_keyrings
+        chainer = keyring.backends.chainer.ChainerBackend()
+        
+        # Try to delete a password that doesn't exist anywhere
+        with pytest.raises(PasswordDeleteError):
+            chainer.delete_password('nonexistent', 'user')


### PR DESCRIPTION
## Summary

Fixes #697 where `ChainerBackend.delete_password()` was only trying the first backend instead of iterating through all backends in the chain.

The issue occurred when a password existed in a lower priority backend but not in the highest priority one. The `delete_password` method would try only the first (highest priority) backend, get a `PasswordDeleteError`, and fail immediately.

## Changes

- Updated `ChainerBackend.delete_password()` to iterate through all backends, similar to how `get_password()` works
- Now catches `PasswordDeleteError` exceptions and continues trying other backends
- If all backends fail to delete the password, raises the last `PasswordDeleteError` encountered
- Added comprehensive test coverage for the new behavior

## Testing

Added two new test cases:
1. `test_delete_password_tries_all_backends` - Verifies that deletion succeeds when password exists only in a lower priority backend
2. `test_delete_password_raises_if_all_backends_fail` - Verifies that appropriate error is raised when password doesn't exist in any backend

All existing tests continue to pass.