### PR TITLE
Use logged in user's username by default, when none specified

### DIFF
--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -93,7 +93,8 @@ class CommandLineTool:
         )
         try:
             default_user = getpass.getuser()
-        except (OSError, ModuleNotFoundError):
+        except (OSError, KeyError, ModuleNotFoundError):
+            # on recent Python versions (>=3.13), `OSError` should suffice
             default_user = None
         self.parser.add_argument(
             'username',

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -94,6 +94,7 @@ class CommandLineTool:
         self.parser.add_argument(
             'username',
             nargs="?",
+            default=getpass.getuser(),
         )
         completion.install(self.parser)
 

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -93,7 +93,7 @@ class CommandLineTool:
         )
         try:
             default_user = getpass.getuser()
-        except OSError:
+        except OSError, ModuleNotFoundError:
             default_user = None
         self.parser.add_argument(
             'username',

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -91,10 +91,14 @@ class CommandLineTool:
             'service',
             nargs="?",
         )
+        try:
+            default_user = getpass.getuser()
+        except OSError:
+            default_user = None
         self.parser.add_argument(
             'username',
             nargs="?",
-            default=getpass.getuser(),
+            default=default_user,
         )
         completion.install(self.parser)
 

--- a/keyring/cli.py
+++ b/keyring/cli.py
@@ -93,7 +93,7 @@ class CommandLineTool:
         )
         try:
             default_user = getpass.getuser()
-        except OSError, ModuleNotFoundError:
+        except (OSError, ModuleNotFoundError):
             default_user = None
         self.parser.add_argument(
             'username',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ type = [
 	# upstream
 	"pytest-mypy >= 1.0.1",
 
+	## workaround for python/mypy#20454
+	"mypy < 1.19; python_implementation == 'PyPy'",
+
 	# local
 	"pygobject-stubs",
 	"shtab", # Optional install for completion

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import getpass
 import itertools
+import os
 import sys
 from unittest import mock
 
@@ -40,6 +41,19 @@ def mocked_set():
 def mocked_get_credential():
     with mock.patch('keyring.cli.get_credential') as get_credential:
         yield get_credential
+
+
+def test_set_no_user(monkeypatch, mocked_set):
+    for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
+        monkeypatch.delitem(os.environ, name, raising=False)
+    monkeypatch.setattr(os, 'getuid', lambda: -1)
+    tool = cli.CommandLineTool()
+    tool.service = 'svc'
+    tool.username = 'usr'
+    monkeypatch.setattr(sys.stdin, 'isatty', lambda: True)
+    monkeypatch.setattr(getpass, 'getpass', PasswordEmitter('foo123'))
+    tool.do_set()
+    mocked_set.assert_called_once_with('svc', 'usr', 'foo123')
 
 
 def test_set_interactive(monkeypatch, mocked_set):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def mocked_get_credential():
 def test_set_no_user(monkeypatch, mocked_set):
     for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
         monkeypatch.delitem(os.environ, name, raising=False)
-    monkeypatch.setattr(os, 'getuid', lambda: -1)
+    monkeypatch.setattr(os, 'getuid', lambda: -1, raising=False)
     tool = cli.CommandLineTool()
     tool.service = 'svc'
     tool.username = 'usr'

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 	diff-cover
 commands =
 	pytest {posargs} --cov-report xml
-	diff-cover coverage.xml --compare-branch=origin/main --html-report diffcov.html
+	diff-cover coverage.xml --compare-branch=origin/main --format html:diffcov.html
 	diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:docs]


### PR DESCRIPTION
Arguably, this is a minor quality of life enhancement,
that _could_ also obviate the need to specify a username
in index-urls for `pip`, making those more portable... 