### PR TITLE
Remove obsolete call to win32_ver

### DIFF
--- a/keyring/util/platform_.py
+++ b/keyring/util/platform_.py
@@ -4,7 +4,6 @@ import platform
 
 
 def _data_root_Windows():
-    release, version, csd, ptype = platform.win32_ver()
     root = pathlib.Path(
         os.environ.get('LOCALAPPDATA', os.environ.get('ProgramData', '.'))
     )


### PR DESCRIPTION
platform.win32_ver is a deceptively complex function, and its output is no longer used here, so omit the call entirely.

(I encountered this in a test environment that had all unexpected subprocess invocations blocked via `pytest-subprocess`, and it picked up the attempted call to `ver` from `platform.win32_ver()`)