### PR TITLE
macOS: use SecItemUpdate to preserve keychain ACL on password change

### DIFF
--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -18,6 +18,7 @@ class error:
     item_not_found = -25300
     keychain_denied = -128
     sec_auth_failed = -25293
+    sec_param = -50
     plist_missing = -67030
     sec_interaction_not_allowed = -25308
 
@@ -56,6 +57,10 @@ SecItemCopyMatching.argtypes = (c_void_p, c_void_p)
 SecItemDelete = _sec.SecItemDelete
 SecItemDelete.restype = OS_status
 SecItemDelete.argtypes = (c_void_p,)
+
+SecItemUpdate = _sec.SecItemUpdate
+SecItemUpdate.restype = OS_status
+SecItemUpdate.argtypes = (c_void_p, c_void_p)
 
 CFDataGetBytePtr = _found.CFDataGetBytePtr
 CFDataGetBytePtr.restype = c_void_p
@@ -123,6 +128,8 @@ class Error(Exception):
                 "Security Auth Failure: make sure "
                 "executable is signed with codesign util",
             )
+        if status == error.sec_param:
+            raise InvalidParametersError(status, "Invalid parameters")
         raise cls(status, "Unknown Error")
 
 
@@ -135,6 +142,10 @@ class KeychainDenied(Error):
 
 
 class SecAuthFailure(Error):
+    pass
+
+
+class InvalidParametersError(Error):
     pass
 
 
@@ -159,18 +170,18 @@ def find_generic_password(kc_name, service, username, not_found_ok=False):
 
 
 def set_generic_password(name, service, username, password):
+    # Try to update in place first. This preserves the keychain item's
+    # access control list (ACL), avoiding repeated "Keychain Access"
+    # prompts on macOS when the item is later read.
+    try:
+        _update_generic_password(service, username, password)
+        return
+    except (NotFound, InvalidParametersError):
+        pass
+    # Fall back to delete+add if update fails, e.g. because the item doesn't exist.
     with contextlib.suppress(NotFound):
         delete_generic_password(name, service, username)
-
-    q = create_query(
-        kSecClass=k_('kSecClassGenericPassword'),
-        kSecAttrService=service,
-        kSecAttrAccount=username,
-        kSecValueData=password,
-    )
-
-    status = SecItemAdd(q, None)
-    Error.raise_for_status(status)
+    _add_generic_password(service, username, password)
 
 
 def delete_generic_password(name, service, username):
@@ -181,4 +192,28 @@ def delete_generic_password(name, service, username):
     )
 
     status = SecItemDelete(q)
+    Error.raise_for_status(status)
+
+
+def _add_generic_password(service, username, password):
+    q = create_query(
+        kSecClass=k_('kSecClassGenericPassword'),
+        kSecAttrService=service,
+        kSecAttrAccount=username,
+        kSecValueData=password,
+    )
+    status = SecItemAdd(q, None)
+    Error.raise_for_status(status)
+
+
+def _update_generic_password(service, username, password):
+    query = create_query(
+        kSecClass=k_('kSecClassGenericPassword'),
+        kSecAttrService=service,
+        kSecAttrAccount=username,
+    )
+    update_attrs = create_query(
+        kSecValueData=password,
+    )
+    status = SecItemUpdate(query, update_attrs)
     Error.raise_for_status(status)

--- a/keyring/backends/macOS/api.py
+++ b/keyring/backends/macOS/api.py
@@ -177,11 +177,10 @@ def set_generic_password(name, service, username, password):
         _update_generic_password(service, username, password)
         return
     except (NotFound, InvalidParametersError):
-        pass
-    # Fall back to delete+add if update fails, e.g. because the item doesn't exist.
-    with contextlib.suppress(NotFound):
-        delete_generic_password(name, service, username)
-    _add_generic_password(service, username, password)
+        # Fall back to delete+add if update fails, e.g. because the item doesn't exist.
+        with contextlib.suppress(NotFound):
+            delete_generic_password(name, service, username)
+        _add_generic_password(service, username, password)
 
 
 def delete_generic_password(name, service, username):

--- a/tests/backends/test_macOS.py
+++ b/tests/backends/test_macOS.py
@@ -12,3 +12,122 @@ from keyring.testing.backend import BackendBasicTests
 class Test_macOSKeychain(BackendBasicTests):
     def init_keyring(self):
         return macOS.Keyring()
+
+
+class FakeKeychain:
+    """In-memory fake of the macOS Security framework SecItem* functions.
+
+    Mimics the real behaviour: items are stored in a dict, and each
+    operation returns the appropriate OSStatus code. Tracks which
+    operations were used so tests can verify that updates go via
+    SecItemUpdate (preserving the ACL) rather than delete+add.
+    """
+
+    ERR_SUCCESS = 0
+    ERR_ITEM_NOT_FOUND = -25300
+    ERR_DUPLICATE_ITEM = -25299
+
+    def __init__(self):
+        self.store = {}  # (service, username) -> password
+        self.update_count = 0
+        self.add_count = 0
+        self.delete_count = 0
+
+    def SecItemUpdate(self, query, attrs):
+        # We can't inspect the CFDictionary args from Python, so
+        # the tests call set_generic_password which builds them.
+        # Instead, peek at the store keyed by the service/username
+        # that was passed to set_generic_password.
+        key = self._current_key
+        if key not in self.store:
+            return self.ERR_ITEM_NOT_FOUND
+        self.store[key] = self._current_password
+        self.update_count += 1
+        return self.ERR_SUCCESS
+
+    def SecItemAdd(self, query, result):
+        key = self._current_key
+        if key in self.store:
+            return self.ERR_DUPLICATE_ITEM
+        self.store[key] = self._current_password
+        self.add_count += 1
+        return self.ERR_SUCCESS
+
+    def SecItemDelete(self, query):
+        key = self._current_key
+        if key not in self.store:
+            return self.ERR_ITEM_NOT_FOUND
+        del self.store[key]
+        self.delete_count += 1
+        return self.ERR_SUCCESS
+
+    def patch(self, monkeypatch, api):
+        monkeypatch.setattr(api, 'SecItemUpdate', self.SecItemUpdate)
+        monkeypatch.setattr(api, 'SecItemAdd', self.SecItemAdd)
+        monkeypatch.setattr(api, 'SecItemDelete', self.SecItemDelete)
+
+    def set(self, api, name, service, username, password):
+        """Call api.set_generic_password, providing context for the fakes."""
+        self._current_key = (service, username)
+        self._current_password = password
+        api.set_generic_password(name, service, username, password)
+
+    def delete(self, api, name, service, username):
+        """Call api.delete_generic_password, providing context for the fakes."""
+        self._current_key = (service, username)
+        api.delete_generic_password(name, service, username)
+
+
+@pytest.mark.skipif(
+    not keyring.backends.macOS.Keyring.viable,
+    reason="macOS backend not viable",
+)
+class TestSetGenericPasswordUsesUpdate:
+    """Verify set_generic_password prefers SecItemUpdate over delete+add.
+
+    Deleting and re-adding a keychain item resets its access control list
+    (ACL), causing repeated "Keychain Access" password prompts on macOS.
+    Using SecItemUpdate preserves the ACL.
+    """
+
+    def test_update_existing_item(self, monkeypatch):
+        """Updating an existing item should use SecItemUpdate, not delete+add."""
+        kc = FakeKeychain()
+        api = macOS.api
+        kc.patch(monkeypatch, api)
+
+        # Seed an existing item.
+        kc.store[('svc', 'user')] = 'old-pw'
+
+        kc.set(api, None, 'svc', 'user', 'new-pw')
+
+        assert kc.store[('svc', 'user')] == 'new-pw'
+        assert kc.update_count == 1
+        assert kc.delete_count == 0
+        assert kc.add_count == 0
+
+    def test_add_new_item(self, monkeypatch):
+        """Adding a brand-new item should fall back to SecItemAdd."""
+        kc = FakeKeychain()
+        api = macOS.api
+        kc.patch(monkeypatch, api)
+
+        kc.set(api, None, 'svc', 'user', 'pw')
+
+        assert kc.store[('svc', 'user')] == 'pw'
+        assert kc.add_count == 1
+
+    def test_repeated_updates_never_delete(self, monkeypatch):
+        """Multiple updates to the same item should never delete it."""
+        kc = FakeKeychain()
+        api = macOS.api
+        kc.patch(monkeypatch, api)
+
+        kc.set(api, None, 'svc', 'user', 'pw1')  # initial add
+        kc.set(api, None, 'svc', 'user', 'pw2')  # update
+        kc.set(api, None, 'svc', 'user', 'pw3')  # update again
+
+        assert kc.store[('svc', 'user')] == 'pw3'
+        assert kc.add_count == 1    # only the first set
+        assert kc.update_count == 2  # subsequent sets
+        assert kc.delete_count == 0  # never deleted


### PR DESCRIPTION
## Summary

`set_generic_password` previously deleted and re-added keychain items on every update. This resets the item's access control list (ACL), wiping any "Always Allow" grants and causing repeated Keychain Access password prompts.

This PR uses `SecItemUpdate` to modify items in place, preserving the ACL. Falls back to delete+add when the item doesn't exist yet or the update is not possible (e.g. `SecItemUpdate` returns `errSecParam` for empty password data).

## Related issues

- #619 — Multiple Password Popups on macOS for Multiple Credentials When the Python Binary Updates
- #512 — Changing "Access Control" on macOS
- #644 — Two keyring password dialogs are triggered

## Changes

- Add `SecItemUpdate` binding alongside existing `SecItemAdd`/`SecItemDelete`
- Add `error.sec_param` (-50) and `InvalidParametersError` exception
- Extract `_update_generic_password` and `_add_generic_password` helpers
- `set_generic_password` tries update-in-place first, falls back to delete+add on `NotFound` or `InvalidParametersError`
- Add `FakeKeychain`-based tests verifying the update-first behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)